### PR TITLE
feat(insight): add missing-collection insight aligned to BIZ_DATE

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/controller/MonitorController.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/controller/MonitorController.java
@@ -154,4 +154,12 @@ public class MonitorController
     {
         return ResponseEntity.ok(statService.getHighTableTimeChangeRateList(days, threshold));
     }
+
+    // 近 N 天内，缺失采集记录的有效表
+    @RequestMapping("/insight/missing-collect")
+    public ResponseEntity<List<Map<String, Object>>> insightMissingCollect(
+        @RequestParam(value = "days", defaultValue = "15") int days)
+    {
+        return ResponseEntity.ok(statService.getMissingCollectTablesInDays(days));
+    }
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/StatService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/StatService.java
@@ -434,6 +434,91 @@ public class StatService
         return jdbcTemplate.queryForList(sql, offset, thresholdPct);
     }
 
+    // 近 N 天内缺失采集记录的有效表（默认每天应采集一次）
+    public List<Map<String, Object>> getMissingCollectTablesInDays(int days)
+    {
+        int safeDays = Math.max(days, 1);
+        int offset = safeDays - 1;
+        LocalDate bizDate = configService.getBizDateAsDate();
+        String sql = """
+            WITH date_span AS (
+              SELECT generate_series(?::date - ?, ?::date, interval '1 day')::date AS biz_date
+            ),
+            valid_tables AS (
+              SELECT
+                id AS tid,
+                source_db,
+                source_table,
+                target_db,
+                target_table
+              FROM vw_etl_table_with_source
+              WHERE status <> 'X'
+                AND COALESCE(enabled, false) = true
+            ),
+            daily AS (
+              SELECT tid, biz_date
+              FROM etl_statistic
+              WHERE biz_date >= (?::date - ?)
+                AND biz_date <= ?::date
+            ),
+            missing AS (
+              SELECT
+                t.tid,
+                t.source_db,
+                t.source_table,
+                t.target_db,
+                t.target_table,
+                d.biz_date
+              FROM valid_tables t
+              CROSS JOIN date_span d
+              LEFT JOIN daily s
+                ON s.tid = t.tid
+               AND s.biz_date = d.biz_date
+              WHERE s.tid IS NULL
+            ),
+            missing_agg AS (
+              SELECT
+                m.tid,
+                m.source_db,
+                m.source_table,
+                m.target_db,
+                m.target_table,
+                COUNT(*) AS missing_days,
+                MIN(m.biz_date) AS first_missing_date,
+                MAX(m.biz_date) AS last_missing_date,
+                string_agg(to_char(m.biz_date, 'YYYY-MM-DD'), ' | ' ORDER BY m.biz_date) AS missing_dates
+              FROM missing m
+              GROUP BY m.tid, m.source_db, m.source_table, m.target_db, m.target_table
+            ),
+            actual AS (
+              SELECT
+                tid,
+                COUNT(*) AS actual_days,
+                MAX(biz_date) AS last_collect_date
+              FROM daily
+              GROUP BY tid
+            )
+            SELECT
+              m.tid,
+              m.source_db,
+              m.source_table,
+              m.target_db,
+              m.target_table,
+              ? AS expected_days,
+              COALESCE(a.actual_days, 0) AS actual_days,
+              m.missing_days,
+              m.first_missing_date,
+              m.last_missing_date,
+              m.missing_dates,
+              a.last_collect_date
+            FROM missing_agg m
+            LEFT JOIN actual a
+              ON m.tid = a.tid
+            ORDER BY m.missing_days DESC, m.last_missing_date DESC, m.source_db, m.source_table
+            """;
+        return jdbcTemplate.queryForList(sql, bizDate, offset, bizDate, bizDate, offset, bizDate, safeDays);
+    }
+
     // 获取指定表 ID 的最后一次采集时间
     public LocalDate getLastEtlDateByTid(long tid)
     {

--- a/frontend/src/service/monitor-service.ts
+++ b/frontend/src/service/monitor-service.ts
@@ -82,5 +82,12 @@ class MonitorService {
       Array<Map<string, any>>
     >
   }
+
+  // 数据洞察：近 N 天内缺失采集的有效表
+  insightMissingCollect(params?: { days?: number }): Promise<Array<Map<string, any>>> {
+    return Requests.get(this.prefix + '/insight/missing-collect', params) as unknown as Promise<
+      Array<Map<string, any>>
+    >
+  }
 }
 export const monitorService = new MonitorService()

--- a/frontend/src/views/data-insight.vue
+++ b/frontend/src/views/data-insight.vue
@@ -203,6 +203,61 @@
       </v-col>
     </v-row>
 
+    <v-row dense class="section-grid">
+      <v-col cols="12" md="12">
+        <v-card flat class="mb-4 section-card">
+          <v-card-text class="section-body">
+            <div class="section-header">
+              <div class="section-title">{{ missingCollectTable.title }}</div>
+              <div class="header-actions">
+                <v-btn
+                  size="small"
+                  variant="tonal"
+                  color="primary"
+                  prepend-icon="mdi-download"
+                  :disabled="!filteredMissingCollect.length"
+                  @click="
+                    exportCsv(
+                      missingCollectTable.headers,
+                      filteredMissingCollect,
+                      'insight-missing-collect'
+                    )
+                  "
+                >
+                  导出
+                </v-btn>
+              </div>
+            </div>
+            <v-data-table
+              :items="filteredMissingCollect"
+              :headers="missingCollectTable.headers"
+              density="compact"
+              :sort-by="missingCollectTable.sortBy"
+              class="elevation-1"
+              hide-no-data
+            >
+              <template #item.missing_dates="{ item }">
+                <div class="missing-dates-compact">
+                  <span class="text-caption text-medium-emphasis">
+                    {{ compactMissingDates(item) }}
+                  </span>
+                  <v-btn
+                    size="x-small"
+                    variant="text"
+                    color="primary"
+                    :disabled="!hasMissingDates(item)"
+                    @click="openMissingDatesDialog(item)"
+                  >
+                    查看明细
+                  </v-btn>
+                </div>
+              </template>
+            </v-data-table>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
     <v-dialog v-model="confirmDialog.open" max-width="520">
       <v-card>
         <v-card-title class="text-subtitle-1 font-weight-medium">确认禁用采集</v-card-title>
@@ -231,6 +286,33 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <v-dialog v-model="missingDatesDialog.open" max-width="760">
+      <v-card>
+        <v-card-title class="text-subtitle-1 font-weight-medium">缺失日期明细</v-card-title>
+        <v-card-text>
+          <div class="mb-3">
+            目标表：{{ missingDatesDialog.item?.source_db }}.{{ missingDatesDialog.item?.source_table }}
+          </div>
+          <div class="mb-3">缺失天数：{{ missingDatesDialog.dates.length }}</div>
+          <div class="missing-date-chips">
+            <v-chip
+              v-for="date in missingDatesDialog.dates"
+              :key="date"
+              size="small"
+              color="warning"
+              variant="tonal"
+            >
+              {{ date }}
+            </v-chip>
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="closeMissingDatesDialog">关闭</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
@@ -256,7 +338,8 @@
     noChange: [] as Array<Map<string, any>>,
     lowChange: [] as Array<Map<string, any>>,
     highChange: [] as Array<Map<string, any>>,
-    timeChange: [] as Array<Map<string, any>>
+    timeChange: [] as Array<Map<string, any>>,
+    missingCollect: [] as Array<Map<string, any>>
   })
 
   const noChangeTable = computed(() => ({
@@ -341,6 +424,24 @@
     ]
   }))
 
+  const missingCollectTable = computed(() => ({
+    title: `近 ${filters.value.days} 天内，缺失采集记录的有效表`,
+    sortBy: <SortItem[]>[{ key: 'missing_days', order: 'desc' }],
+    headers: <DataTableHeader[]>[
+      { title: '表 ID', key: 'tid', align: 'end', width: '64px' },
+      { title: '源库', key: 'source_db' },
+      { title: '表名', key: 'source_table' },
+      { title: '目标库表', key: 'target_table_full', value: (item) => formatTargetTable(item) },
+      { title: '应采集天数', key: 'expected_days', align: 'end' },
+      { title: '实际采集天数', key: 'actual_days', align: 'end' },
+      { title: '缺失天数', key: 'missing_days', align: 'end' },
+      { title: '首次缺失日期', key: 'first_missing_date' },
+      { title: '最近缺失日期', key: 'last_missing_date' },
+      { title: '最近采集日期', key: 'last_collect_date' },
+      { title: '缺失日期', key: 'missing_dates', sortable: false, width: '280px' }
+    ]
+  }))
+
   const normalizeKeyword = (value: string) => value.trim().toLowerCase()
 
   const formatTargetTable = (item: any) => {
@@ -366,6 +467,7 @@
   const filteredLowChange = computed(() => filterByKeyword(data.value.lowChange))
   const filteredHighChange = computed(() => filterByKeyword(data.value.highChange))
   const filteredTimeChange = computed(() => filterByKeyword(data.value.timeChange))
+  const filteredMissingCollect = computed(() => filterByKeyword(data.value.missingCollect))
 
   const loadInsights = async () => {
     loading.value = true
@@ -373,16 +475,18 @@
       const params = {
         days: filters.value.days
       }
-      const [noChange, lowChange, highChange, timeChange] = await Promise.all([
+      const [noChange, lowChange, highChange, timeChange, missingCollect] = await Promise.all([
         monitorService.insightNoChange(params),
         monitorService.insightLowChange({ ...params, threshold: filters.value.lowRate }),
         monitorService.insightHighChange({ ...params, threshold: filters.value.highRate }),
-        monitorService.insightTimeChange({ ...params, threshold: filters.value.timeRate })
+        monitorService.insightTimeChange({ ...params, threshold: filters.value.timeRate }),
+        monitorService.insightMissingCollect(params)
       ])
       data.value.noChange = noChange ?? []
       data.value.lowChange = lowChange ?? []
       data.value.highChange = highChange ?? []
       data.value.timeChange = timeChange ?? []
+      data.value.missingCollect = missingCollect ?? []
     } catch (error) {
       console.error('Failed to load insight data:', error)
     } finally {
@@ -455,6 +559,39 @@
       confirmDialog.value.loading = false
     }
   }
+
+  const parseMissingDates = (value: string) =>
+    String(value ?? '')
+      .split('|')
+      .map((d) => d.trim())
+      .filter(Boolean)
+
+  const compactMissingDates = (item: any) => {
+    const dates = parseMissingDates(item?.missing_dates)
+    if (!dates.length) return '-'
+    if (dates.length <= 2) return dates.join('、')
+    return `${dates[0]} ~ ${dates[dates.length - 1]}（共 ${dates.length} 天）`
+  }
+
+  const hasMissingDates = (item: any) => parseMissingDates(item?.missing_dates).length > 0
+
+  const missingDatesDialog = ref({
+    open: false,
+    item: null as any,
+    dates: [] as string[]
+  })
+
+  const openMissingDatesDialog = (item: any) => {
+    missingDatesDialog.value.item = item
+    missingDatesDialog.value.dates = parseMissingDates(item?.missing_dates)
+    missingDatesDialog.value.open = true
+  }
+
+  const closeMissingDatesDialog = () => {
+    missingDatesDialog.value.open = false
+    missingDatesDialog.value.item = null
+    missingDatesDialog.value.dates = []
+  }
 </script>
 
 <route lang="json">
@@ -525,5 +662,21 @@
 
   .filter-keyword {
     min-width: 220px;
+  }
+
+  .missing-dates-compact {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .missing-date-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    max-height: 320px;
+    overflow: auto;
   }
 </style>


### PR DESCRIPTION
## Motivation
The Data Insight page currently highlights row-count and runtime volatility, but it cannot directly answer a core operational question: **which tables were expected to run but have no collection record** in the selected period.

Because this project uses `BIZ_DATE` as the scheduling and reporting anchor, using natural date (`current_date`) can produce misleading insight results. We need a business-date-aligned, explicit "missing collection" signal to reduce blind spots in monitoring.

## What Changed
### Backend
- Added a new API endpoint:
  - `GET /monitor/insight/missing-collect?days=N`
- Implemented missing-collection aggregation in `StatService#getMissingCollectTablesInDays`.
- Computation window is now anchored by `SystemConfigService#getBizDateAsDate()` (`BIZ_DATE`) instead of `current_date`.
- Eligibility rule follows requested semantics:
  - `etl_table.status <> 'X'`
  - source is enabled (`enabled = true` from `vw_etl_table_with_source`)
- Query output includes:
  - `expected_days`
  - `actual_days`
  - `missing_days`
  - `first_missing_date`
  - `last_missing_date`
  - `missing_dates` (detail list)
  - `last_collect_date`

### Frontend
- Added `monitorService.insightMissingCollect()`.
- Added a new insight section in `data-insight.vue` for missing collection tables.
- Improved readability of missing-date details:
  - table cell now shows compact summary (range + count)
  - full date list moved to a detail dialog (`查看明细`)
  - avoids oversized columns and visual clutter when missing-date count is high

## Design Notes
- Missing detection is performed by comparing:
  - expected records: `(eligible tables) x (date series in [BIZ_DATE-(N-1), BIZ_DATE])`
  - actual records: existing `(tid, biz_date)` in `etl_statistic`
- A missing day is identified when expected row has no matching `etl_statistic` row.
- `last_missing_date` is computed as `MAX(missing biz_date)` per table.

## Validation
- `yarn build:backend` ✅
- `yarn build:frontend` ✅

## Attention / Caveats
- The insight assumes one expected collection per day for eligible tables.
- The endpoint intentionally does not include tables with zero missing days.
- Date semantics are now business-date driven; this is a behavioral improvement and may differ from previous natural-date expectations.
