### PR TITLE
feat(schema): honor table creation date in missing insight

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/model/EtlTable.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/model/EtlTable.java
@@ -12,8 +12,11 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Formula;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Date;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 
 @Entity
 @Table(name = "etl_table")
@@ -106,4 +109,28 @@ public class EtlTable
 
     @Formula("LOWER(concat_ws(',', source_db || '.' || source_table , target_db || '.' || target_table , part_kind , part_name , filter))")
     private String filterColumn;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist()
+    {
+        LocalDateTime now = LocalDateTime.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate()
+    {
+        updatedAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/StatService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/StatService.java
@@ -437,8 +437,7 @@ public class StatService
     // 近 N 天内缺失采集记录的有效表（默认每天应采集一次）
     public List<Map<String, Object>> getMissingCollectTablesInDays(int days)
     {
-        int safeDays = Math.max(days, 1);
-        int offset = safeDays - 1;
+        int offset = Math.max(days - 1, 0);
         LocalDate bizDate = configService.getBizDateAsDate();
         String sql = """
             WITH date_span AS (
@@ -450,7 +449,8 @@ public class StatService
                 source_db,
                 source_table,
                 target_db,
-                target_table
+                target_table,
+                COALESCE(created_at::date, ?::date) AS created_date
               FROM vw_etl_table_with_source
               WHERE status <> 'X'
                 AND COALESCE(enabled, false) = true
@@ -468,6 +468,7 @@ public class StatService
                 t.source_table,
                 t.target_db,
                 t.target_table,
+                t.created_date,
                 d.biz_date
               FROM valid_tables t
               CROSS JOIN date_span d
@@ -475,6 +476,7 @@ public class StatService
                 ON s.tid = t.tid
                AND s.biz_date = d.biz_date
               WHERE s.tid IS NULL
+                AND d.biz_date >= t.created_date
             ),
             missing_agg AS (
               SELECT
@@ -483,12 +485,13 @@ public class StatService
                 m.source_table,
                 m.target_db,
                 m.target_table,
+                m.created_date,
                 COUNT(*) AS missing_days,
                 MIN(m.biz_date) AS first_missing_date,
                 MAX(m.biz_date) AS last_missing_date,
                 string_agg(to_char(m.biz_date, 'YYYY-MM-DD'), ' | ' ORDER BY m.biz_date) AS missing_dates
               FROM missing m
-              GROUP BY m.tid, m.source_db, m.source_table, m.target_db, m.target_table
+              GROUP BY m.tid, m.source_db, m.source_table, m.target_db, m.target_table, m.created_date
             ),
             actual AS (
               SELECT
@@ -504,7 +507,7 @@ public class StatService
               m.source_table,
               m.target_db,
               m.target_table,
-              ? AS expected_days,
+              GREATEST(0, (?::date - GREATEST(m.created_date, ?::date - ?)) + 1) AS expected_days,
               COALESCE(a.actual_days, 0) AS actual_days,
               m.missing_days,
               m.first_missing_date,
@@ -516,7 +519,12 @@ public class StatService
               ON m.tid = a.tid
             ORDER BY m.missing_days DESC, m.last_missing_date DESC, m.source_db, m.source_table
             """;
-        return jdbcTemplate.queryForList(sql, bizDate, offset, bizDate, bizDate, offset, bizDate, safeDays);
+        return jdbcTemplate.queryForList(sql,
+            bizDate, offset, bizDate,      // date_span
+            bizDate,                       // coalesce created_at fallback
+            bizDate, offset, bizDate,      // daily
+            bizDate, bizDate, offset       // expected_days params
+        );
     }
 
     // 获取指定表 ID 的最后一次采集时间

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -197,7 +197,9 @@ create table public.etl_table
   status          char          default 'U'::bpchar                             not null,
   split_pk        varchar(50)   default NULL::character varying,
   auto_pk         boolean       default true                                    not null,
-  write_mode varchar(20) default 'overwrite' not null
+  write_mode varchar(20) default 'overwrite' not null,
+  created_at     timestamp     default CURRENT_TIMESTAMP not null,
+  updated_at     timestamp     default CURRENT_TIMESTAMP not null
 );
 
 create table if not exists public.etl_target
@@ -270,6 +272,26 @@ comment on column public.etl_table.split_pk is '切分主键';
 comment on column public.etl_table.auto_pk is '自动获取切分字段';
 
 comment on column etl_table.write_mode is '覆盖默认，默认为 overwrite，可选为 append,nonConflict';
+comment on column public.etl_table.created_at is '记录创建时间';
+comment on column public.etl_table.updated_at is '记录最近更新时间';
+
+-- keep updated_at in sync on updates
+create or replace function public.fn_etl_table_set_updated_at()
+returns trigger
+language plpgsql
+as
+$$
+begin
+  new.updated_at := CURRENT_TIMESTAMP;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_etl_table_set_updated_at on public.etl_table;
+create trigger trg_etl_table_set_updated_at
+  before update on public.etl_table
+  for each row
+  execute function public.fn_etl_table_set_updated_at();
 
 alter table public.etl_table
   add column if not exists target_id int;


### PR DESCRIPTION
## Motivation
Missing-collection insight should not flag days before a table existed. We also need reliable audit timestamps on `etl_table` rows for both DB- and app-driven updates.

## What Changed
- Schema: added `created_at`, `updated_at` with defaults; added trigger to keep `updated_at` fresh on UPDATE.
- Entity: mapped the new fields and added `@PrePersist/@PreUpdate` hooks so JPA updates also refresh `updated_at`.
- Insight logic: missing-collection window now ignores days earlier than each table’s creation date and recalculates `expected_days` per table using the BIZ_DATE window.

## Validation
- `yarn build:backend`

## Notes / Caveats
- Apply the schema change (new columns + trigger) to the target environments before relying on the insight results.
- Assumes one expected run per day for eligible tables; tables with no missing days remain excluded by design.
