### PR TITLE
feat: support table-level reader/writer plugin config merge

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/model/EtlTable.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/model/EtlTable.java
@@ -1,22 +1,25 @@
 package com.wgzhao.addax.admin.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Date;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.Date;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 
 @Entity
 @Table(name = "etl_table")
@@ -100,6 +103,14 @@ public class EtlTable
 
     @Column(name = "target_id")
     private Long targetId;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "reader_plugin_config", columnDefinition = "jsonb")
+    private JsonNode readerPluginConfig;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "writer_plugin_config", columnDefinition = "jsonb")
+    private JsonNode writerPluginConfig;
 
     /**
      * 表级调度时间点（每天的 HH:mm），为空表示继承 etl_source.start_at

--- a/backend/src/main/java/com/wgzhao/addax/admin/model/VwEtlTableWithSource.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/model/VwEtlTableWithSource.java
@@ -1,12 +1,16 @@
 package com.wgzhao.addax.admin.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Data;
 import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 /**
  * 映射 vw_etl_table_with_source 视图
@@ -61,6 +65,12 @@ public class VwEtlTableWithSource
     private Boolean autoPk;
     private String writeMode;
     private Long targetId;
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "reader_plugin_config")
+    private JsonNode readerPluginConfig;
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "writer_plugin_config")
+    private JsonNode writerPluginConfig;
     private String targetType;
     private String targetCode;
     private String targetName;

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/JobContentService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/JobContentService.java
@@ -1,5 +1,8 @@
 package com.wgzhao.addax.admin.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.wgzhao.addax.admin.common.DbType;
 import com.wgzhao.addax.admin.common.JourKind;
 import com.wgzhao.addax.admin.common.TableStatus;
@@ -11,6 +14,12 @@ import com.wgzhao.addax.admin.model.EtlJour;
 import com.wgzhao.addax.admin.model.VwEtlTableWithSource;
 import com.wgzhao.addax.admin.repository.EtlJobRepo;
 import com.wgzhao.addax.admin.repository.VwEtlTableWithSourceRepo;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.StringSubstitutor;
@@ -18,12 +27,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static com.wgzhao.addax.admin.common.Constants.DELETED_PLACEHOLDER_PREFIX;
 import static com.wgzhao.addax.admin.common.Constants.SPECIAL_FILTER_PLACEHOLDER;
@@ -47,6 +50,7 @@ public class JobContentService
     private final TargetService targetService;
     private final RiskLogService riskLogService;
     private final StatService statService;
+    private final ObjectMapper objectMapper;
 
     /**
      * 获取指定采集表的采集任务模板内容
@@ -81,13 +85,69 @@ public class JobContentService
 
         String jobTemplate = configService.getRdbms2HdfsJobTemplate();
         StringSubstitutor substitutor = new StringSubstitutor(values);
-        String job = substitutor.replace(jobTemplate);
+        String job = mergePluginConfigIntoJob(substitutor.replace(jobTemplate), etlTable);
 
         EtlJob etlJob = new EtlJob(etlTable.getId(), job);
         jobRepo.save(etlJob);
         jourService.successJour(etlJour);
         log.info("表 {}.{} 更新完成", etlTable.getTargetDb(), etlTable.getTargetTable());
         return TaskResultDto.success("更新采集任务模板成功", 0);
+    }
+
+    private String mergePluginConfigIntoJob(String job, VwEtlTableWithSource etlTable)
+    {
+        JsonNode readerConfig = etlTable.getReaderPluginConfig();
+        JsonNode writerConfig = etlTable.getWriterPluginConfig();
+        if ((readerConfig == null || readerConfig.isNull()) && (writerConfig == null || writerConfig.isNull())) {
+            return job;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(job);
+            JsonNode contentNode = root.path("job").path("content");
+            if (!(contentNode instanceof ObjectNode contentObject)) {
+                log.warn("任务模板结构不符合预期，缺少 job.content 对象，tid={}", etlTable.getId());
+                return job;
+            }
+            mergeConfigToParameter(contentObject, "reader", readerConfig, etlTable.getId());
+            mergeConfigToParameter(contentObject, "writer", writerConfig, etlTable.getId());
+            return objectMapper.writeValueAsString(root);
+        }
+        catch (Exception ex) {
+            log.warn("合并插件配置失败，tid={}, err={}", etlTable.getId(), ex.getMessage());
+            return job;
+        }
+    }
+
+    private void mergeConfigToParameter(ObjectNode contentObject, String pluginName, JsonNode customConfig, Long tableId)
+    {
+        if (customConfig == null || customConfig.isNull()) {
+            return;
+        }
+        if (!customConfig.isObject()) {
+            log.warn("{} 插件配置必须是 JSON 对象，tid={}", pluginName, tableId);
+            return;
+        }
+
+        JsonNode pluginNode = contentObject.get(pluginName);
+        if (!(pluginNode instanceof ObjectNode pluginObject)) {
+            log.warn("任务模板结构不符合预期，缺少 {} 对象，tid={}", pluginName, tableId);
+            return;
+        }
+
+        JsonNode parameterNode = pluginObject.get("parameter");
+        ObjectNode parameterObject;
+        if (parameterNode == null || parameterNode.isNull()) {
+            parameterObject = pluginObject.putObject("parameter");
+        }
+        else if (parameterNode instanceof ObjectNode objectNode) {
+            parameterObject = objectNode;
+        }
+        else {
+            log.warn("任务模板结构不符合预期，{}.parameter 不是对象，tid={}", pluginName, tableId);
+            return;
+        }
+
+        customConfig.fields().forEachRemaining(entry -> parameterObject.set(entry.getKey(), entry.getValue()));
     }
 
     private String fillRdbmsReaderJob(VwEtlTableWithSource vTable)

--- a/frontend/src/components/table/TableDetail.vue
+++ b/frontend/src/components/table/TableDetail.vue
@@ -207,6 +207,36 @@
                         </div>
                       </v-col>
                       <v-col cols="12">
+                        <div class="field-stack field-stack--textarea">
+                          <div class="field-label">读取插件配置(JSON)</div>
+                          <v-textarea
+                            variant="outlined"
+                            density="compact"
+                            v-model="readerPluginConfigText"
+                            placeholder='例如: {"fetchSize": 50000}'
+                            :rules="[rules.jsonObjectOrEmpty]"
+                            rows="4"
+                            auto-grow
+                            hide-details="auto"
+                          ></v-textarea>
+                        </div>
+                      </v-col>
+                      <v-col cols="12">
+                        <div class="field-stack field-stack--textarea">
+                          <div class="field-label">写入插件配置(JSON)</div>
+                          <v-textarea
+                            variant="outlined"
+                            density="compact"
+                            v-model="writerPluginConfigText"
+                            placeholder='例如: {"writeMode": "append"}'
+                            :rules="[rules.jsonObjectOrEmpty]"
+                            rows="4"
+                            auto-grow
+                            hide-details="auto"
+                          ></v-textarea>
+                        </div>
+                      </v-col>
+                      <v-col cols="12">
                         <div class="field-stack">
                           <div class="field-label">切分字段</div>
                           <v-text-field
@@ -386,11 +416,61 @@ const rules = {
     const n = Number(v)
     return (!Number.isNaN(n) && n >= 0) || '必须为非负数'
   },
-  dateFormat: (v) => PARTITION_FORMATS.includes(v) || '请选择有效的日期格式'
+  dateFormat: (v) => PARTITION_FORMATS.includes(v) || '请选择有效的日期格式',
+  jsonObjectOrEmpty: (v) => {
+    if (v === null || v === undefined || v === '') return true
+    try {
+      const parsed = JSON.parse(v)
+      return (!!parsed && typeof parsed === 'object' && !Array.isArray(parsed)) || '必须为 JSON 对象'
+    } catch {
+      return '请输入合法 JSON'
+    }
+  }
 }
 
 // 创建本地的响应式副本用于编辑
 const table = ref<VEtlWithSource>({ ...props.table });
+const readerPluginConfigText = ref('')
+const writerPluginConfigText = ref('')
+
+const toJsonText = (value: unknown): string => {
+  if (value === null || value === undefined || value === '') return ''
+  if (typeof value === 'string') {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2)
+    } catch {
+      return value
+    }
+  }
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return ''
+  }
+}
+
+const parseJsonObjectOrNull = (value: string, fieldName: string) => {
+  const raw = value.trim()
+  if (!raw) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error(`${fieldName} 不是合法 JSON`)
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${fieldName} 必须为 JSON 对象`)
+  }
+  return parsed as Record<string, unknown>
+}
+
+const syncTableData = (newTable: VEtlWithSource) => {
+  table.value = { ...newTable }
+  readerPluginConfigText.value = toJsonText(newTable.readerPluginConfig)
+  writerPluginConfigText.value = toJsonText(newTable.writerPluginConfig)
+}
+
+syncTableData(props.table)
 
 // 表级调度为空时，继承自采集源的调度时间
 const inheritedStartAt = computed(() => {
@@ -403,7 +483,7 @@ const inheritedStartAt = computed(() => {
 
 // 监听props变化，同步更新本地副本
 watch(() => props.table, (newTable) => {
-  table.value = { ...newTable };
+  syncTableData(newTable)
 }, { deep: true });
 
 // define emit
@@ -467,11 +547,24 @@ onMounted(async () => {
 const saveOds = async () => {
   if (formRef.value && typeof formRef.value.validate === 'function') {
     const valid = await formRef.value.validate()
-    if (!valid) {
+    if (!valid.valid) {
       notify('请修正表单错误', 'error')
       return
     }
   }
+
+  let readerPluginConfig: Record<string, unknown> | null
+  let writerPluginConfig: Record<string, unknown> | null
+  try {
+    readerPluginConfig = parseJsonObjectOrNull(readerPluginConfigText.value, '读取插件配置')
+    writerPluginConfig = parseJsonObjectOrNull(writerPluginConfigText.value, '写入插件配置')
+  } catch (e) {
+    notify((e as Error).message, 'error')
+    return
+  }
+
+  table.value.readerPluginConfig = readerPluginConfig
+  table.value.writerPluginConfig = writerPluginConfig
 
   const etlTableData: Partial<EtlTable> = {
     id: table.value.id,
@@ -498,6 +591,8 @@ const saveOds = async () => {
     writeMode: table.value.writeMode || 'overwrite',
     startAt: table.value.startAt || null,
     targetId: table.value.targetId ?? null,
+    readerPluginConfig,
+    writerPluginConfig,
     createdAt: table.value.createdAt,
     updatedAt: table.value.updatedAt,
   };
@@ -568,6 +663,10 @@ const showPlaceholderInfoDialog = () => {
   grid-template-columns: 110px minmax(0, 1fr);
   column-gap: 16px;
   align-items: center;
+}
+
+.field-stack--textarea {
+  align-items: start;
 }
 
 .field-label {

--- a/frontend/src/types/database.ts
+++ b/frontend/src/types/database.ts
@@ -218,6 +218,8 @@ export interface EtlTable {
   tblComment?: string // 目标表的注释
   writeMode: string // 写入模式: overwrite|append|nonConflict
   targetId?: number | null // 目标端ID，关联 etl_target
+  readerPluginConfig?: Record<string, unknown> | string | null // reader.parameter 的自定义配置(JSON对象)
+  writerPluginConfig?: Record<string, unknown> | string | null // writer.parameter 的自定义配置(JSON对象)
   createdAt?: Date // 创建时间
   updatedAt?: Date // 更新时间
 }

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -198,6 +198,8 @@ create table public.etl_table
   split_pk        varchar(50)   default NULL::character varying,
   auto_pk         boolean       default true                                    not null,
   write_mode varchar(20) default 'overwrite' not null,
+  reader_plugin_config jsonb,
+  writer_plugin_config jsonb,
   created_at     timestamp     default CURRENT_TIMESTAMP not null,
   updated_at     timestamp     default CURRENT_TIMESTAMP not null
 );
@@ -272,6 +274,8 @@ comment on column public.etl_table.split_pk is '切分主键';
 comment on column public.etl_table.auto_pk is '自动获取切分字段';
 
 comment on column etl_table.write_mode is '覆盖默认，默认为 overwrite，可选为 append,nonConflict';
+comment on column public.etl_table.reader_plugin_config is '读取插件自定义配置(JSON)，将合并到 reader.parameter';
+comment on column public.etl_table.writer_plugin_config is '写入插件自定义配置(JSON)，将合并到 writer.parameter';
 comment on column public.etl_table.created_at is '记录创建时间';
 comment on column public.etl_table.updated_at is '记录最近更新时间';
 
@@ -314,7 +318,15 @@ create index if not exists idx_etl_table_target_id
 alter table public.etl_table
   add column if not exists start_at time;
 
+alter table public.etl_table
+  add column if not exists reader_plugin_config jsonb;
+
+alter table public.etl_table
+  add column if not exists writer_plugin_config jsonb;
+
 comment on column public.etl_table.start_at is '表级采集定时启动时间点；为空表示继承 etl_source.start_at';
+comment on column public.etl_table.reader_plugin_config is '读取插件自定义配置(JSON)，将合并到 reader.parameter';
+comment on column public.etl_table.writer_plugin_config is '写入插件自定义配置(JSON)，将合并到 writer.parameter';
 
 create index if not exists idx_etl_table_start_at_not_null
   on public.etl_table (start_at)
@@ -607,7 +619,7 @@ comment on column public.risk_log.tid is '关联表 ID';
 
 comment on column public.risk_log.created_at is '创建时间';
 
-create view vw_etl_table_with_source
+create or replace view vw_etl_table_with_source
    as
 SELECT t.*,
        s.code,


### PR DESCRIPTION
## Motivation / Background
Some collection tables require plugin-level parameter overrides that cannot be expressed by the shared global reader/writer templates. This change adds table-level custom plugin config for reader and writer so special cases can be handled without forking templates.

## What Changed
- Added two new fields on `etl_table`:
  - `reader_plugin_config` (JSON)
  - `writer_plugin_config` (JSON)
- Updated backend models:
  - `EtlTable` includes JSON-mapped fields for reader/writer plugin config.
  - `VwEtlTableWithSource` includes the same fields for view-based reads.
- Updated job generation in `JobContentService`:
  - After template rendering, merge user-provided top-level keys into:
    - `job.content.reader.parameter`
    - `job.content.writer.parameter`
  - If a custom config is invalid/non-object or target nodes are not objects, log warning and skip merge for that side.
- Updated frontend table detail form:
  - Added JSON textarea inputs for reader/writer plugin config.
  - Added validation: empty is allowed; non-empty must be a JSON object.
  - Save payload now includes `readerPluginConfig` and `writerPluginConfig`.
- Updated type definitions and schema script accordingly.

## Design / Implementation Notes
- Scope intentionally follows the agreed simplified mode:
  - Only supports `job.content.reader` and `job.content.writer`.
  - Merge target is fixed to `reader.parameter` and `writer.parameter`.
  - Merge strategy is top-level key overlay (no deep merge).
- SQL script uses idempotent `add column if not exists` and `create or replace view` for safer rollout.

## Validation
- `yarn build:frontend` ✅
- `yarn build:backend` ✅
- `bun run build` ✅

## Risks / Caveats / Follow-ups
- Existing runtime DB must apply schema migration before using new UI fields.
- Merge is top-level only by design; nested object merge is not included.
- Invalid JSON is blocked in UI; backend merge path is defensive and will skip invalid/non-object payloads.