### PR TITLE
feat: add etl table change history

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/controller/TableController.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/controller/TableController.java
@@ -7,9 +7,11 @@ import com.wgzhao.addax.admin.exception.ApiException;
 import com.wgzhao.addax.admin.model.EtlColumn;
 import com.wgzhao.addax.admin.model.EtlStatistic;
 import com.wgzhao.addax.admin.model.EtlTable;
+import com.wgzhao.addax.admin.model.EtlTableChangeLog;
 import com.wgzhao.addax.admin.model.VwEtlTableWithSource;
 import com.wgzhao.addax.admin.repository.EtlTableRepo;
 import com.wgzhao.addax.admin.service.ColumnService;
+import com.wgzhao.addax.admin.service.EtlTableChangeLogService;
 import com.wgzhao.addax.admin.service.JobContentService;
 import com.wgzhao.addax.admin.service.StatService;
 import com.wgzhao.addax.admin.service.TableService;
@@ -61,6 +63,7 @@ public class TableController
      * 作业内容服务
      */
     private final JobContentService jobContentService;
+    private final EtlTableChangeLogService changeLogService;
 
     /**
      * 分页查询采集表
@@ -148,8 +151,28 @@ public class TableController
         if (!etlTableRepo.existsById(tableId)) {
             throw new ApiException(404, "Table not found");
         }
-        EtlTable updated = etlTableRepo.save(etl);
+        EtlTable updated = tableService.updateTable(etl, getCurrentUsername());
         return ResponseEntity.ok(updated);
+    }
+
+    @GetMapping("/{tableId}/changes")
+    public ResponseEntity<PageResponse<EtlTableChangeLog>> getTableChanges(
+        @PathVariable("tableId") long tableId,
+        @RequestParam(value = "page", defaultValue = "0") int page,
+        @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
+        @RequestParam(value = "field", required = false) String field)
+    {
+        if (!etlTableRepo.existsById(tableId)) {
+            throw new ApiException(404, "Table not found");
+        }
+        if (page < 0) {
+            page = 0;
+        }
+        if (pageSize == -1) {
+            pageSize = Integer.MAX_VALUE;
+        }
+        Page<EtlTableChangeLog> result = changeLogService.getTableChanges(tableId, page, pageSize, field);
+        return ResponseEntity.ok(PageResponse.from(result));
     }
 
     /**

--- a/backend/src/main/java/com/wgzhao/addax/admin/model/EtlTableChangeLog.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/model/EtlTableChangeLog.java
@@ -1,0 +1,58 @@
+package com.wgzhao.addax.admin.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Data;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "etl_table_change_log")
+@Data
+public class EtlTableChangeLog
+{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tid", nullable = false)
+    private Long tid;
+
+    @Column(name = "source_db", length = 32)
+    private String sourceDb;
+
+    @Column(name = "source_table", length = 64)
+    private String sourceTable;
+
+    @Column(name = "target_db", length = 50)
+    private String targetDb;
+
+    @Column(name = "target_table", length = 200)
+    private String targetTable;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "changed_fields", columnDefinition = "jsonb", nullable = false)
+    private JsonNode changedFields;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "old_values", columnDefinition = "jsonb", nullable = false)
+    private JsonNode oldValues;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "new_values", columnDefinition = "jsonb", nullable = false)
+    private JsonNode newValues;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @Column(name = "changed_at")
+    private LocalDateTime changedAt;
+
+    @Column(name = "changed_by", length = 100)
+    private String changedBy;
+}

--- a/backend/src/main/java/com/wgzhao/addax/admin/repository/EtlTableChangeLogRepo.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/repository/EtlTableChangeLogRepo.java
@@ -1,0 +1,32 @@
+package com.wgzhao.addax.admin.repository;
+
+import com.wgzhao.addax.admin.model.EtlTableChangeLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EtlTableChangeLogRepo
+    extends JpaRepository<EtlTableChangeLog, Long>
+{
+    Page<EtlTableChangeLog> findByTidOrderByChangedAtDescIdDesc(Long tid, Pageable pageable);
+
+    @Query(
+        value = """
+            select *
+            from etl_table_change_log
+            where tid = :tid
+              and jsonb_exists(changed_fields, :field)
+            order by changed_at desc, id desc
+            """,
+        countQuery = """
+            select count(*)
+            from etl_table_change_log
+            where tid = :tid
+              and jsonb_exists(changed_fields, :field)
+            """,
+        nativeQuery = true
+    )
+    Page<EtlTableChangeLog> findByTidAndChangedField(@Param("tid") Long tid, @Param("field") String field, Pageable pageable);
+}

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/EtlTableChangeLogService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/EtlTableChangeLogService.java
@@ -1,0 +1,27 @@
+package com.wgzhao.addax.admin.service;
+
+import com.wgzhao.addax.admin.model.EtlTableChangeLog;
+import com.wgzhao.addax.admin.repository.EtlTableChangeLogRepo;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class EtlTableChangeLogService
+{
+    private final EtlTableChangeLogRepo repo;
+
+    public Page<EtlTableChangeLog> getTableChanges(long tableId, int page, int size, String field)
+    {
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.max(size, 1);
+        Pageable pageable = PageRequest.of(safePage, safeSize);
+        if (field == null || field.isBlank()) {
+            return repo.findByTidOrderByChangedAtDescIdDesc(tableId, pageable);
+        }
+        return repo.findByTidAndChangedField(tableId, field.trim(), pageable);
+    }
+}

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/TableService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/TableService.java
@@ -9,6 +9,7 @@ import com.wgzhao.addax.admin.redis.RedisLockService;
 import com.wgzhao.addax.admin.repository.EtlTableRepo;
 import com.wgzhao.addax.admin.repository.VwEtlTableWithSourceRepo;
 import com.wgzhao.addax.admin.utils.QueryUtil;
+import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.StringSubstitutor;
@@ -45,6 +46,7 @@ public class TableService
     private final RedisLockService redisLockService;
     private final SystemConfigService configService;
     private final UserNotificationService userNotificationService;
+    private final EntityManager entityManager;
 
     /**
      * 刷新指定采集表的资源（如字段、模板等）
@@ -573,6 +575,22 @@ public class TableService
     public EtlTable createTable(EtlTable etl)
     {
         return etlTableRepo.save(etl);
+    }
+
+    @Transactional
+    public EtlTable updateTable(EtlTable etl, String username)
+    {
+        setChangedBy(username);
+        return etlTableRepo.save(etl);
+    }
+
+    private void setChangedBy(String username)
+    {
+        String safeUsername = username == null ? "" : username;
+        entityManager
+            .createNativeQuery("select set_config('addax.changed_by', :username, true)")
+            .setParameter("username", safeUsername)
+            .getSingleResult();
     }
 
     /**

--- a/frontend/src/components/table/TableDetail.vue
+++ b/frontend/src/components/table/TableDetail.vue
@@ -345,6 +345,14 @@
       </v-card-text>
 
       <v-card-actions class="action-bar">
+        <v-btn
+          variant="text"
+          color="primary"
+          prepend-icon="mdi-history"
+          @click="openChangeHistory"
+        >
+          变更历史
+        </v-btn>
         <v-spacer />
         <v-btn color="primary" @click="saveOds">保存</v-btn>
         <v-btn variant="plain" @click="emit('closeDialog')">关闭</v-btn>
@@ -372,6 +380,81 @@
           </v-card-actions>
         </v-card>
       </v-dialog>
+      <v-dialog v-model="showChangeHistory" max-width="980" scrollable>
+        <v-card>
+          <v-card-title class="history-title">
+            <v-icon size="20" color="primary">mdi-history</v-icon>
+            <span>变更历史</span>
+          </v-card-title>
+          <v-card-text>
+            <v-text-field
+              v-model="changeFieldFilter"
+              variant="outlined"
+              density="compact"
+              clearable
+              prepend-inner-icon="mdi-filter-outline"
+              placeholder="按字段筛选，例如 filter"
+              hide-details
+              class="mb-3"
+              @keyup.enter="reloadChangeHistory"
+              @click:clear="clearChangeFieldFilter"
+            />
+            <v-table density="compact" class="history-table">
+              <thead>
+                <tr>
+                  <th>变更时间</th>
+                  <th>操作者</th>
+                  <th>字段</th>
+                  <th>旧值</th>
+                  <th>新值</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-if="changeLogLoading">
+                  <td colspan="5" class="history-empty">加载中...</td>
+                </tr>
+                <tr v-else-if="changeLogs.length === 0">
+                  <td colspan="5" class="history-empty">暂无记录</td>
+                </tr>
+                <template v-else>
+                  <tr v-for="log in changeLogs" :key="log.id">
+                    <td class="history-time">{{ log.changedAt || '-' }}</td>
+                    <td>{{ log.changedBy || '-' }}</td>
+                    <td>
+                      <div class="history-fields">
+                        <v-chip
+                          v-for="field in normalizeChangedFields(log.changedFields)"
+                          :key="`${log.id}-${field}`"
+                          size="small"
+                          variant="tonal"
+                          color="primary"
+                        >
+                          {{ field }}
+                        </v-chip>
+                      </div>
+                    </td>
+                    <td><pre class="history-value">{{ formatChangeValues(log.oldValues) }}</pre></td>
+                    <td><pre class="history-value">{{ formatChangeValues(log.newValues) }}</pre></td>
+                  </tr>
+                </template>
+              </tbody>
+            </v-table>
+            <div class="history-pagination">
+              <v-pagination
+                v-model="changeLogPage"
+                :length="changeLogPageCount"
+                density="comfortable"
+                size="small"
+                @update:model-value="loadChangeHistory"
+              />
+            </div>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn variant="text" @click="showChangeHistory = false">关闭</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
     </v-form>
   </v-card>
 </template>
@@ -381,7 +464,7 @@ import { computed, onMounted, ref, watch } from "vue";
 import { notify } from '@/stores/notifier';
 import tableService from "@/service/table-service";
 import targetService from "@/service/target-service";
-import { VEtlWithSource, EtlTable, EtlTarget } from "@/types/database";
+import { VEtlWithSource, EtlTable, EtlTarget, EtlTableChangeLog } from "@/types/database";
 import { TABLE_STATUS_OPTIONS, PARTITION_FORMATS, HDFS_COMPRESS_FORMATS } from "@/utils";
 
 const props = defineProps({
@@ -432,6 +515,15 @@ const rules = {
 const table = ref<VEtlWithSource>({ ...props.table });
 const readerPluginConfigText = ref('')
 const writerPluginConfigText = ref('')
+const showChangeHistory = ref(false)
+const changeLogs = ref<EtlTableChangeLog[]>([])
+const changeLogLoading = ref(false)
+const changeLogPage = ref(1)
+const changeLogPageSize = 10
+const changeLogTotal = ref(0)
+const changeFieldFilter = ref('')
+
+const changeLogPageCount = computed(() => Math.max(1, Math.ceil(changeLogTotal.value / changeLogPageSize)))
 
 const toJsonText = (value: unknown): string => {
   if (value === null || value === undefined || value === '') return ''
@@ -468,6 +560,57 @@ const syncTableData = (newTable: VEtlWithSource) => {
   table.value = { ...newTable }
   readerPluginConfigText.value = toJsonText(newTable.readerPluginConfig)
   writerPluginConfigText.value = toJsonText(newTable.writerPluginConfig)
+}
+
+const normalizeChangedFields = (value: string[] | string) => {
+  if (Array.isArray(value)) return value
+  if (!value) return []
+  try {
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed.map(String) : [String(value)]
+  } catch {
+    return [String(value)]
+  }
+}
+
+const formatChangeValues = (value: Record<string, unknown> | null | undefined) => {
+  if (!value) return '-'
+  return JSON.stringify(value, null, 2)
+}
+
+const loadChangeHistory = async () => {
+  if (!table.value.id) return
+  changeLogLoading.value = true
+  try {
+    const result = await tableService.fetchChangeLogs(
+      table.value.id,
+      changeLogPage.value - 1,
+      changeLogPageSize,
+      changeFieldFilter.value || undefined
+    )
+    changeLogs.value = result.content
+    changeLogTotal.value = result.totalElements
+  } catch (e) {
+    notify(`加载变更历史失败: ${(e as Error).message}`, 'error')
+  } finally {
+    changeLogLoading.value = false
+  }
+}
+
+const openChangeHistory = async () => {
+  showChangeHistory.value = true
+  changeLogPage.value = 1
+  await loadChangeHistory()
+}
+
+const reloadChangeHistory = async () => {
+  changeLogPage.value = 1
+  await loadChangeHistory()
+}
+
+const clearChangeFieldFilter = async () => {
+  changeFieldFilter.value = ''
+  await reloadChangeHistory()
 }
 
 syncTableData(props.table)
@@ -731,5 +874,57 @@ const showPlaceholderInfoDialog = () => {
 .action-bar {
   border-top: 1px solid rgba(0, 0, 0, 0.06);
   padding-top: 12px;
+}
+
+.history-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.history-table {
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.1);
+  border-radius: 8px;
+}
+
+.history-table th {
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.history-time {
+  min-width: 150px;
+  white-space: nowrap;
+}
+
+.history-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-width: 140px;
+}
+
+.history-value {
+  max-width: 280px;
+  max-height: 180px;
+  overflow: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.history-empty {
+  height: 72px;
+  text-align: center;
+  color: rgb(var(--v-theme-on-surface-variant));
+}
+
+.history-pagination {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 12px;
 }
 </style>

--- a/frontend/src/service/table-service.ts
+++ b/frontend/src/service/table-service.ts
@@ -1,5 +1,5 @@
 import Requests from '@/utils/requests'
-import type { EtlTable, VEtlWithSource, EtlColumn, EtlStatistic } from '@/types/database'
+import type { EtlTable, VEtlWithSource, EtlColumn, EtlStatistic, EtlTableChangeLog } from '@/types/database'
 import type { Page } from '@/types'
 
 class TableService {
@@ -47,6 +47,19 @@ class TableService {
     return Requests.get(`${this.prefix}/${tableId}/statistics`) as unknown as Promise<
       EtlStatistic[]
     >
+  }
+
+  fetchChangeLogs(
+    tableId: number,
+    page = 0,
+    pageSize = 10,
+    field?: string
+  ): Promise<Page<EtlTableChangeLog>> {
+    return Requests.get(`${this.prefix}/${tableId}/changes`, {
+      page,
+      pageSize,
+      field
+    }) as unknown as Promise<Page<EtlTableChangeLog>>
   }
 
   // 批量保存采集表

--- a/frontend/src/types/database.ts
+++ b/frontend/src/types/database.ts
@@ -224,6 +224,20 @@ export interface EtlTable {
   updatedAt?: Date // 更新时间
 }
 
+export interface EtlTableChangeLog {
+  id: number
+  tid: number
+  sourceDb?: string
+  sourceTable?: string
+  targetDb?: string
+  targetTable?: string
+  changedFields: string[] | string
+  oldValues: Record<string, unknown>
+  newValues: Record<string, unknown>
+  changedAt?: string
+  changedBy?: string | null
+}
+
 export interface TableMeta {
   name: string // 表名
   comment?: string // 表注释

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -204,6 +204,31 @@ create table public.etl_table
   updated_at     timestamp     default CURRENT_TIMESTAMP not null
 );
 
+create table if not exists public.etl_table_change_log
+(
+  id             bigserial primary key,
+  tid            bigint not null,
+  source_db      varchar(32),
+  source_table   varchar(64),
+  target_db      varchar(50),
+  target_table   varchar(200),
+  changed_fields jsonb not null,
+  old_values     jsonb not null,
+  new_values     jsonb not null,
+  changed_at     timestamp default CURRENT_TIMESTAMP not null,
+  changed_by     varchar(100)
+);
+
+comment on table public.etl_table_change_log is '采集表配置变更历史';
+comment on column public.etl_table_change_log.tid is '采集表ID，对应 etl_table.id';
+comment on column public.etl_table_change_log.changed_fields is '本次变更的字段名列表';
+comment on column public.etl_table_change_log.old_values is '本次变更前的字段值';
+comment on column public.etl_table_change_log.new_values is '本次变更后的字段值';
+comment on column public.etl_table_change_log.changed_by is '触发本次变更的用户';
+
+create index if not exists idx_etl_table_change_log_tid_changed_at
+  on public.etl_table_change_log (tid, changed_at desc, id desc);
+
 create table if not exists public.etl_target
 (
   id               bigserial primary key,
@@ -296,6 +321,87 @@ create trigger trg_etl_table_set_updated_at
   before update on public.etl_table
   for each row
   execute function public.fn_etl_table_set_updated_at();
+
+create or replace function public.fn_etl_table_record_change()
+returns trigger
+language plpgsql
+as
+$$
+declare
+  old_row jsonb;
+  new_row jsonb;
+  changed_fields jsonb;
+  old_values jsonb;
+  new_values jsonb;
+begin
+  old_row := to_jsonb(old)
+    - 'status'
+    - 'duration'
+    - 'retry_cnt'
+    - 'start_time'
+    - 'end_time'
+    - 'created_at'
+    - 'updated_at'
+    - 'max_runtime'
+    - 'kind';
+  new_row := to_jsonb(new)
+    - 'status'
+    - 'duration'
+    - 'retry_cnt'
+    - 'start_time'
+    - 'end_time'
+    - 'created_at'
+    - 'updated_at'
+    - 'max_runtime'
+    - 'kind';
+
+  select coalesce(jsonb_agg(n.key order by n.key), '[]'::jsonb)
+  into changed_fields
+  from jsonb_each(new_row) n
+  join jsonb_each(old_row) o on o.key = n.key
+  where o.value is distinct from n.value;
+
+  if changed_fields = '[]'::jsonb then
+    return new;
+  end if;
+
+  select coalesce(jsonb_object_agg(field_name, old_row -> field_name), '{}'::jsonb),
+         coalesce(jsonb_object_agg(field_name, new_row -> field_name), '{}'::jsonb)
+  into old_values, new_values
+  from jsonb_array_elements_text(changed_fields) as fields(field_name);
+
+  insert into public.etl_table_change_log (
+    tid,
+    source_db,
+    source_table,
+    target_db,
+    target_table,
+    changed_fields,
+    old_values,
+    new_values,
+    changed_by
+  )
+  values (
+    new.id,
+    new.source_db,
+    new.source_table,
+    new.target_db,
+    new.target_table,
+    changed_fields,
+    old_values,
+    new_values,
+    nullif(current_setting('addax.changed_by', true), '')
+  );
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_etl_table_record_change on public.etl_table;
+create trigger trg_etl_table_record_change
+  after update on public.etl_table
+  for each row
+  execute function public.fn_etl_table_record_change();
 
 alter table public.etl_table
   add column if not exists target_id int;


### PR DESCRIPTION
## Motivation / Background

`etl_table` contains configuration that directly affects how collection jobs read and write data. Runtime fields such as status and duration change frequently, but configuration changes such as filter rules need to be traceable so operators can understand when downstream query conditions or collection behavior changed.

## What Changed

- Added `etl_table_change_log` plus a PostgreSQL trigger that records one history row per meaningful `etl_table` update.
- The trigger excludes runtime/non-configuration fields: `status`, `duration`, `retry_cnt`, `start_time`, `end_time`, `created_at`, `updated_at`, `max_runtime`, and `kind`.
- Added backend model, repository, service, and `GET /tables/{tableId}/changes` for paginated history lookup with optional field filtering.
- Set the current username into the DB session during table updates so the trigger can populate `changed_by`.
- Added a table-detail history dialog in the frontend for viewing changed fields and old/new values.

## Design / Implementation Notes

- Auditing is implemented in PostgreSQL so JPQL updates, native SQL, and future scripts are covered instead of relying only on application-layer diffing.
- Each update produces at most one history row with `changed_fields`, `old_values`, and `new_values` JSONB payloads.
- `schema_change_log` remains dedicated to column/schema evolution and is not reused for table configuration history.

## Validation

- `bun build:backend`
- `bun build:frontend`
- `git diff --check`
- Applied the DDL to the local configured PostgreSQL database and verified trigger scenarios with JDBC:
  - excluded runtime fields do not create history rows
  - `filter` changes create one history row
  - multiple config fields changed in one update create one history row
  - JSONB plugin config changes are captured
- User acceptance testing completed with no issues found.

## Risks / Caveats / Follow-ups

- Existing rows do not get an initial snapshot; history starts from updates after the trigger is installed.
- Deletes are not recorded in this change.
