### PR TITLE
fix: address security and quality issues from code review

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/config/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/config/CustomAccessDeniedHandler.java
@@ -4,17 +4,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wgzhao.addax.admin.dto.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+@Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler
     implements AccessDeniedHandler
 {
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
@@ -22,7 +26,7 @@ public class CustomAccessDeniedHandler
     {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType(APPLICATION_JSON_VALUE);
-        ApiResponse<Object> apiResponse = ApiResponse.error(HttpServletResponse.SC_FORBIDDEN, "Forbidden: " + accessDeniedException.getMessage());
+        ApiResponse<Object> apiResponse = ApiResponse.error(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
     }
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/config/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/config/CustomAuthenticationEntryPoint.java
@@ -4,18 +4,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wgzhao.addax.admin.dto.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+@Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint
     implements AuthenticationEntryPoint
 {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
@@ -26,7 +30,7 @@ public class CustomAuthenticationEntryPoint
         response.setContentType(APPLICATION_JSON_VALUE);
 
         // 构建统一的错误响应
-        ApiResponse<Object> apiResponse = ApiResponse.error(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized: " + authException.getMessage());
+        ApiResponse<Object> apiResponse = ApiResponse.error(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
 
         // 写出 JSON 响应
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));

--- a/backend/src/main/java/com/wgzhao/addax/admin/config/JwtFilter.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/config/JwtFilter.java
@@ -1,6 +1,9 @@
 package com.wgzhao.addax.admin.config;
 
 import com.wgzhao.addax.admin.service.JwtService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,24 +39,33 @@ public class JwtFilter
         throws ServletException, IOException
     {
         log.debug("doFilterInternal with jwtFilter");
-        String username = null;
         String token = jwtService.resolveToken(request);
-        if (token != null) {
-            username = jwtService.extractUsername(token);
-        }
 
-        if (username == null) {
+        if (token == null) {
             filterChain.doFilter(request, response);
             return;
         }
-        // validate token is expired or not
-        if (jwtService.isTokenExpired(token)) {
-            log.debug("token expired, username: {}", username);
-            // return 401 with a JSON message indicating the token is expired
+
+        Claims claims;
+        try {
+            claims = jwtService.parseTokenClaims(token);
+        }
+        catch (ExpiredJwtException ex) {
+            log.debug("JWT token expired for request {}", request.getRequestURI());
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json;charset=UTF-8");
-            // simple JSON body; keep it small to avoid dependencies
             response.getWriter().write("{\"message\":\"token 已过期\"}");
+            return;
+        }
+        catch (JwtException | IllegalArgumentException ex) {
+            log.debug("Invalid JWT token: {}", ex.getMessage());
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String username = claims.getSubject();
+        if (username == null || username.isBlank()) {
+            filterChain.doFilter(request, response);
             return;
         }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/config/SecurityConfiguration.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/config/SecurityConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.beans.factory.annotation.Value;
 
 import javax.sql.DataSource;
 
@@ -27,13 +28,15 @@ import javax.sql.DataSource;
 public class SecurityConfiguration
 {
     private final JwtFilter jwtFilter;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http)
         throws Exception
     {
         http.csrf(AbstractHttpConfigurer::disable)
-            .cors(AbstractHttpConfigurer::disable)
+            .cors(Customizer.withDefaults())
             .authorizeHttpRequests((authorize) -> authorize
                 // 公开接口
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
@@ -52,14 +55,14 @@ public class SecurityConfiguration
                 // 其他情况默认需要登录
                 .anyRequest().authenticated()
             )
-            .httpBasic(Customizer.withDefaults())
-            .formLogin(Customizer.withDefaults())
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
             .exceptionHandling((exceptionHandling) -> exceptionHandling
                 // 无 token/无效 token -> 401
-                .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                .authenticationEntryPoint(authenticationEntryPoint)
                 // 已认证但权限不足 -> 403
-                .accessDeniedHandler(new CustomAccessDeniedHandler())
+                .accessDeniedHandler(accessDeniedHandler)
             );
 
         return http.build();
@@ -85,7 +88,7 @@ public class SecurityConfiguration
     }
 
     @Bean
-    public WebMvcConfigurer corsConfigurer()
+    public WebMvcConfigurer corsConfigurer(@Value("${cors.allowed-origins:*}") String allowedOrigins)
     {
         return new WebMvcConfigurer()
         {
@@ -93,7 +96,7 @@ public class SecurityConfiguration
             public void addCorsMappings(CorsRegistry registry)
             {
                 registry.addMapping("/**")
-                    .allowedOrigins("*")
+                    .allowedOrigins(allowedOrigins.split(","))
                     .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
             }
         };

--- a/backend/src/main/java/com/wgzhao/addax/admin/controller/AuthController.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/controller/AuthController.java
@@ -4,8 +4,11 @@ import com.wgzhao.addax.admin.dto.ApiResponse;
 import com.wgzhao.addax.admin.dto.AuthRequestDTO;
 import com.wgzhao.addax.admin.dto.ChangePasswordDTO;
 import com.wgzhao.addax.admin.service.JwtService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -52,7 +55,7 @@ public class AuthController
      * @return JWT 令牌或认证失败信息
      */
     @PostMapping("/login")
-    public ApiResponse<String> AuthenticateAndGetToken(@RequestBody AuthRequestDTO authRequestDTO)
+    public ResponseEntity<ApiResponse<String>> AuthenticateAndGetToken(@Valid @RequestBody AuthRequestDTO authRequestDTO)
     {
         try {
             Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(authRequestDTO.username(), authRequestDTO.password()));
@@ -62,20 +65,20 @@ public class AuthController
                     : authentication.getAuthorities().stream()
                     .map((item) -> normalizeAuthority(item.getAuthority()))
                     .toList();
-                return ApiResponse.success(jwtService.generateToken(authRequestDTO.username(), authorities));
+                return ResponseEntity.ok(ApiResponse.success(jwtService.generateToken(authRequestDTO.username(), authorities)));
             }
             else {
-                return ApiResponse.error(401, "账号或密码不正确");
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error(401, "账号或密码不正确"));
             }
         }
         catch (org.springframework.security.core.AuthenticationException ex) {
             // 认证失败（如密码错误或用户不存在）——返回友好消息，而不是让异常传播导致 500
             log.debug("authentication failed for user {}: {}", authRequestDTO.username(), ex.getMessage());
-            return ApiResponse.error(401, "账号或密码不正确");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error(401, "账号或密码不正确"));
         }
         catch (Exception ex) {
             log.error("unexpected error during authentication", ex);
-            return ApiResponse.error(500, "internal error");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(500, "internal error"));
         }
     }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/controller/SourceController.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/controller/SourceController.java
@@ -102,6 +102,10 @@ public class SourceController
         if (!Objects.equals(existing.getCode(), etlSource.getCode())) {
             throw new ApiException(400, "Source code cannot be modified");
         }
+        // Sentinel means the client didn't change the password — keep the stored one.
+        if (EtlSource.PASS_SENTINEL.equals(etlSource.getPass())) {
+            etlSource.setPass(existing.getPass());
+        }
         // 校验采集时间与切日时间的距离，更新时如果不满足规则则直接失败并返回提示
         validateStartAt(etlSource.getStartAt());
         sourceService.save(etlSource);
@@ -156,7 +160,16 @@ public class SourceController
     @PostMapping("/test-connect")
     public ResponseEntity<Boolean> testConnect(@RequestBody DbConnectDto payload)
     {
-        boolean isConnected = DbUtil.testConnection(payload.url(), payload.username(), payload.password());
+        String password = payload.password();
+        // Sentinel means the client didn't supply a new password — resolve from DB.
+        if (EtlSource.PASS_SENTINEL.equals(password) && payload.sourceId() != null) {
+            EtlSource source = sourceService.getSource(payload.sourceId());
+            if (source == null) {
+                throw new ApiException(404, "Source not found");
+            }
+            password = source.getPass();
+        }
+        boolean isConnected = DbUtil.testConnection(payload.url(), payload.username(), password);
         return ResponseEntity.ok(isConnected);
     }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/dto/AuthRequestDTO.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/dto/AuthRequestDTO.java
@@ -1,3 +1,8 @@
 package com.wgzhao.addax.admin.dto;
 
-public record AuthRequestDTO(String username, String password) {}
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthRequestDTO(
+    @NotBlank(message = "用户名不能为空") String username,
+    @NotBlank(message = "密码不能为空") String password
+) {}

--- a/backend/src/main/java/com/wgzhao/addax/admin/dto/DbConnectDto.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/dto/DbConnectDto.java
@@ -2,8 +2,8 @@ package com.wgzhao.addax.admin.dto;
 
 /**
  * 数据库连接信息传输对象
- *
+ * sourceId 可选，当 password 为哨兵值时用于从 DB 取回真实密码
  */
-public record DbConnectDto(String url, String username, String password)
+public record DbConnectDto(String url, String username, String password, Integer sourceId)
 {
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/exception/GlobalExceptionHandler.java
@@ -5,27 +5,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.stream.Collectors;
+
 /**
  * 全局异常处理器。
  * 拦截并统一处理 ApiException 和其他未捕获异常，返回标准化的 API 响应。
- * 适用于 Spring Boot 控制器层，保证接口异常信息一致性。
  */
 @ControllerAdvice
 public class GlobalExceptionHandler
 {
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    /**
-     * 处理自定义 ApiException 异常。
-     * 根据异常 code 映射为 HTTP 状态码，返回标准化错误响应。
-     *
-     * @param ex ApiException 异常对象
-     * @return ResponseEntity 包含错误信息和对应 HTTP 状态码
-     */
     @ExceptionHandler(ApiException.class)
     @ResponseBody
     public ResponseEntity<ApiResponse<Object>> handleApiException(ApiException ex)
@@ -42,17 +39,38 @@ public class GlobalExceptionHandler
     }
 
     /**
-     * 处理所有未捕获的异常。
-     * 返回 500 错误响应，记录异常日志。
-     *
-     * @param ex 未捕获的异常对象
-     * @return ResponseEntity 包含错误信息和 500 状态码
+     * Bean Validation 校验失败 (@Valid / @Validated)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseBody
+    public ResponseEntity<ApiResponse<Object>> handleValidationException(MethodArgumentNotValidException ex)
+    {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+            .map(FieldError::getDefaultMessage)
+            .collect(Collectors.joining("; "));
+        log.debug("Validation failed: {}", message);
+        return new ResponseEntity<>(ApiResponse.error(400, message), HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 请求体格式错误（JSON 解析失败）
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseBody
+    public ResponseEntity<ApiResponse<Object>> handleUnreadableException(HttpMessageNotReadableException ex)
+    {
+        log.debug("HTTP message not readable: {}", ex.getMessage());
+        return new ResponseEntity<>(ApiResponse.error(400, "请求体格式错误"), HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 兜底：返回通用错误消息，不暴露异常细节
      */
     @ExceptionHandler(Exception.class)
     @ResponseBody
     public ResponseEntity<ApiResponse<Object>> handleOtherException(Exception ex)
     {
         log.error("Unhandled exception: {}", ex.getMessage(), ex);
-        return new ResponseEntity<>(ApiResponse.error(500, ex.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(ApiResponse.error(500, "Internal server error"), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/model/EtlSource.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/model/EtlSource.java
@@ -1,5 +1,7 @@
 package com.wgzhao.addax.admin.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wgzhao.addax.admin.common.DbType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,6 +22,8 @@ import java.time.LocalTime;
 @Data
 public class EtlSource
 {
+    /** Sentinel returned to the client instead of the real password. */
+    public static final String PASS_SENTINEL = "**UNCHANGED**";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,8 +42,24 @@ public class EtlSource
     @Column(name = "username", length = 64)
     private String username;
 
+    @JsonIgnore   // suppress Lombok's getPass() from serialization
     @Column(name = "pass", length = 64)
     private String pass;
+
+    // Always serializes as the sentinel so the real password never crosses the wire.
+    @JsonProperty("pass")
+    public String getPassDisplay()
+    {
+        return PASS_SENTINEL;
+    }
+
+    // Accepts whatever the client sends (sentinel or new password); the service
+    // layer decides whether to persist it.
+    @JsonProperty("pass")
+    public void setPassDisplay(String value)
+    {
+        this.pass = value;
+    }
 
     @Column(name = "start_at")
     private LocalTime startAt;

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/EtlTargetService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/EtlTargetService.java
@@ -177,7 +177,8 @@ public class EtlTargetService
         DbConnectDto dto = new DbConnectDto(
             getText(node, "url"),
             getText(node, "username"),
-            getText(node, "password")
+            getText(node, "password"),
+            null
         );
         if (dto.url() == null || dto.url().isBlank()) {
             throw new ApiException(400, "connectConfig.url is required");

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/JwtService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/JwtService.java
@@ -2,9 +2,11 @@ package com.wgzhao.addax.admin.service;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,25 +26,24 @@ import java.util.function.Function;
 
 /**
  * JWT服务类，负责生成、解析和校验JWT令牌。
- * 提供令牌生成、提取声明、校验有效性等功能。
+ * 密钥通过 jwt.secret 配置项注入，生产环境应通过 JWT_SECRET 环境变量覆盖。
  */
 @Slf4j
 @Component
 public class JwtService
 {
-    /**
-     * JWT密钥（建议生产环境使用更安全的方式管理）
-     */
-    public final static String SECRET = "4017CCCC60E17DE5C84CF03C6CBE559413EA1606";
-    /**
-     * JWT签名密钥对象
-     */
-    private final static SecretKey KEY = Keys.hmacShaKeyFor(SECRET.getBytes());
+    private final SecretKey key;
+
     /**
      * 令牌过期时间（毫秒）
      */
     @Value("${jwt.expiration}")
     private int accessTokenExpiration;
+
+    public JwtService(@Value("${jwt.secret}") String secret) {
+        // secret is a raw ASCII string; derive key bytes via UTF-8 encoding
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
 
     /**
      * 提取JWT中的指定声明（如用户名、过期时间等）
@@ -104,7 +105,7 @@ public class JwtService
             .subject(username)
             .issuedAt(new Date())
             .expiration(expiryDate)
-            .signWith(KEY)
+            .signWith(key)
             .compact();
     }
 
@@ -188,7 +189,25 @@ public class JwtService
     }
 
     /**
-     * 解析JWT令牌，获取所有声明
+     * 解析JWT令牌，获取所有声明。调用方须自行处理 JwtException。
+     * 令牌过期时抛出 {@link ExpiredJwtException}，格式/签名错误时抛出 {@link JwtException}。
+     *
+     * @param jwtToken JWT令牌
+     * @return Claims对象（不会返回 null）
+     * @throws ExpiredJwtException 令牌已过期
+     * @throws JwtException 令牌无效
+     */
+    public Claims parseTokenClaims(String jwtToken)
+    {
+        return Jwts.parser()
+            .verifyWith(key)
+            .build()
+            .parseSignedClaims(jwtToken)
+            .getPayload();
+    }
+
+    /**
+     * 解析JWT令牌，获取所有声明（兼容旧调用，异常时返回 null）
      *
      * @param jwtToken JWT令牌
      * @return Claims对象或null
@@ -196,12 +215,7 @@ public class JwtService
     private Claims extractAllClaims(String jwtToken)
     {
         try {
-            // 解析并校验JWT令牌
-            return Jwts.parser()
-                .verifyWith(KEY)
-                .build()
-                .parseSignedClaims(jwtToken)
-                .getPayload();
+            return parseTokenClaims(jwtToken);
         }
         catch (ExpiredJwtException ex) {
             log.error("Expired JWT token");

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/UserAdminService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/UserAdminService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -27,14 +28,26 @@ public class UserAdminService
     public List<UserAdminDto> listUsers()
     {
         requireAdmin();
-        List<String> usernames = jdbcTemplate.query(
-            "select username from users order by username",
-            (rs, rowNum) -> rs.getString("username")
-        );
+        // Single JOIN query replacing the previous N+1 pattern (1 query for usernames + N×2 per-user queries)
+        Map<String, UserAdminDto> result = new java.util.LinkedHashMap<>();
+        jdbcTemplate.query(
+            "SELECT u.username, u.enabled, a.authority " +
+            "FROM users u LEFT JOIN authorities a ON u.username = a.username " +
+            "ORDER BY u.username, a.authority",
+            rs -> {
+                String username = rs.getString("username");
+                boolean enabled = rs.getBoolean("enabled");
+                String rawAuthority = rs.getString("authority");
+                String authority = rawAuthority != null ? normalizeAuthority(rawAuthority) : null;
 
-        return usernames.stream()
-            .map(this::toUserAdminDto)
-            .toList();
+                UserAdminDto dto = result.computeIfAbsent(username,
+                    k -> new UserAdminDto(k, enabled, new java.util.ArrayList<>()));
+                if (authority != null && !authority.isBlank()) {
+                    dto.authorities().add(authority);
+                }
+            }
+        );
+        return new java.util.ArrayList<>(result.values());
     }
 
     public UserAdminDto currentUser()

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TargetServiceWithHiveImpl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TargetServiceWithHiveImpl.java
@@ -25,6 +25,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import javax.sql.DataSource;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -48,6 +49,8 @@ import java.util.Properties;
 import java.time.format.DateTimeFormatter;
 import java.util.logging.Logger;
 
+import jakarta.annotation.PreDestroy;
+
 import static com.wgzhao.addax.admin.common.Constants.DEFAULT_PART_FORMAT;
 import static com.wgzhao.addax.admin.common.Constants.DELETED_PLACEHOLDER_PREFIX;
 import static com.wgzhao.addax.admin.common.HiveType.isHiveTypeCompatible;
@@ -70,6 +73,8 @@ public class TargetServiceWithHiveImpl
     private volatile DataSource hiveDataSource;
     // keep a reference to the registered driver shim so we can deregister it if we ever reinit
     private volatile Driver registeredHiveDriver;
+    // classloader holding the hive driver jar; must be closed when driver is re-initialized or on destroy
+    private volatile URLClassLoader hiveClassLoader;
 
     @Override
     public String getType()
@@ -133,8 +138,18 @@ public class TargetServiceWithHiveImpl
         }
 
         URL[] jarUrls = new URL[] {hiveJarFile.toURI().toURL()};
+        // close previous classloader to release JAR file handles and allow GC of old driver classes
+        if (hiveClassLoader != null) {
+            try {
+                hiveClassLoader.close();
+            }
+            catch (IOException ex) {
+                log.warn("Failed to close previous Hive URLClassLoader", ex);
+            }
+        }
         // 创建独立的类加载器
         URLClassLoader classLoader = new URLClassLoader(jarUrls, this.getClass().getClassLoader());
+        this.hiveClassLoader = classLoader;
 
         // We'll set the context class loader only for the period of loading/registering the driver
         ClassLoader previousCl = Thread.currentThread().getContextClassLoader();
@@ -713,4 +728,25 @@ public class TargetServiceWithHiveImpl
                 }
             }
         }
+
+    @PreDestroy
+    public void destroy()
+    {
+        if (registeredHiveDriver != null) {
+            try {
+                DriverManager.deregisterDriver(registeredHiveDriver);
+            }
+            catch (SQLException ex) {
+                log.warn("Failed to deregister Hive driver on shutdown", ex);
+            }
+        }
+        if (hiveClassLoader != null) {
+            try {
+                hiveClassLoader.close();
+            }
+            catch (IOException ex) {
+                log.warn("Failed to close Hive URLClassLoader on shutdown", ex);
+            }
+        }
+    }
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -50,6 +50,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -124,6 +125,11 @@ public class TaskQueueManagerV2Impl
     // node-level concurrency weight in (0.0,1.0]
     private double concurrencyWeight = 1.0;
 
+    // holds futures for cancellation on restart/stop to prevent task accumulation
+    private volatile Future<?> listenFuture;
+    private volatile ScheduledFuture<?> pollFuture;
+    private volatile ScheduledFuture<?> recoverFuture;
+
     @PostConstruct
     public void init()
     {
@@ -138,14 +144,31 @@ public class TaskQueueManagerV2Impl
         this.instanceId = resolveInstanceId();
 
         running = true;
-
-        // 启动 LISTEN 监听器
-        scheduler.execute(this::listenLoop);
-        // 启动定时轮询兜底
-        scheduler.scheduleWithFixedDelay(this::pollAndDispatch, 1, DEFAULT_POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
-        // 启动租约回收（仍保留 DB 层回收以保证兼容）
-        scheduler.scheduleWithFixedDelay(this::recoverLeases, 30, 30, TimeUnit.SECONDS);
+        submitScheduledTasks();
         log.info("Redis-backed arbitration queue started. originalConcurrentLimit={} weight={} effectiveConcurrentLimit={} enqueueCapacity={} instanceId={} ", originalConcurrentLimit, concurrencyWeight, concurrentLimit, enqueueCapacity, instanceId);
+    }
+
+    private void submitScheduledTasks()
+    {
+        // 启动 LISTEN 监听器
+        listenFuture = scheduler.submit(this::listenLoop);
+        // 启动定时轮询兜底
+        pollFuture = scheduler.scheduleWithFixedDelay(this::pollAndDispatch, 1, DEFAULT_POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
+        // 启动租约回收（仍保留 DB 层回收以保证兼容）
+        recoverFuture = scheduler.scheduleWithFixedDelay(this::recoverLeases, 30, 30, TimeUnit.SECONDS);
+    }
+
+    private void cancelScheduledTasks()
+    {
+        if (listenFuture != null) {
+            listenFuture.cancel(true);
+        }
+        if (pollFuture != null) {
+            pollFuture.cancel(false);
+        }
+        if (recoverFuture != null) {
+            recoverFuture.cancel(false);
+        }
     }
 
     private String resolveInstanceId()
@@ -742,6 +765,7 @@ public class TaskQueueManagerV2Impl
     public void stopQueueMonitor()
     {
         running = false;
+        cancelScheduledTasks();
     }
 
     public void restartQueueMonitor()
@@ -754,9 +778,7 @@ public class TaskQueueManagerV2Impl
             Thread.currentThread().interrupt();
         }
         running = true;
-        scheduler.execute(this::listenLoop);
-        scheduler.scheduleWithFixedDelay(this::pollAndDispatch, 1, DEFAULT_POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
-        scheduler.scheduleWithFixedDelay(this::recoverLeases, 30, 30, TimeUnit.SECONDS);
+        submitScheduledTasks();
     }
 
     public boolean addTaskToQueue(@NonNull EtlTable etlTable)
@@ -818,10 +840,11 @@ public class TaskQueueManagerV2Impl
 
     public void startQueueMonitor()
     {
+        if (running) {
+            return;
+        }
         running = true;
-        scheduler.execute(this::listenLoop);
-        scheduler.scheduleWithFixedDelay(this::pollAndDispatch, 1, DEFAULT_POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
-        scheduler.scheduleWithFixedDelay(this::recoverLeases, 30, 30, TimeUnit.SECONDS);
+        submitScheduledTasks();
     }
 
     @SuppressWarnings("unchecked")

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,6 +8,8 @@ spring.mvc.format.time=HH:mm:ss
 
 # 8 hours
 jwt.expiration=691200000
+# Override in production via JWT_SECRET environment variable
+jwt.secret=${JWT_SECRET:4017CCCC60E17DE5C84CF03C6CBE559413EA1606}
 
 spring.web.resources.add-mappings=false
 spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:addax_admin}

--- a/frontend/src/components/source/AddSource.vue
+++ b/frontend/src/components/source/AddSource.vue
@@ -264,7 +264,8 @@ const testConnect = () => {
   sourceService.testConnection({
     url: sourceItem.value.url,
     username: sourceItem.value.username,
-    password: sourceItem.value.pass
+    password: sourceItem.value.pass,
+    sourceId: sourceItem.value.id > 0 ? sourceItem.value.id : undefined
   })
     .then(resp => {
       if (resp) {

--- a/frontend/src/service/source-service.ts
+++ b/frontend/src/service/source-service.ts
@@ -35,7 +35,7 @@ class SourceService {
   }
 
   // 测试数据源连接
-  testConnection(params: { url: string; username: string; password?: string }): Promise<boolean> {
+  testConnection(params: { url: string; username: string; password?: string; sourceId?: number }): Promise<boolean> {
     return Requests.post(`${this.prefix}/test-connect`, params) as unknown as Promise<boolean>
   }
 

--- a/memory.md
+++ b/memory.md
@@ -1,0 +1,39 @@
+# Backend Code Review Fix Summary
+
+> Date: 2026-05-20
+> Branch: `fix/backend-security-and-quality-issues`
+> Build: ✅ BUILD SUCCESS
+
+## 修复文件清单（13 个文件）
+
+| # | 严重等级 | 问题描述 | 涉及文件 | 修复方式 |
+|---|---------|---------|---------|---------|
+| 1 | 🔴 高 | JWT Secret 硬编码在源码中 | `JwtService.java`, `application.properties` | 通过 `@Value("${jwt.secret}")` 构造器注入，支持 `JWT_SECRET` 环境变量覆盖 |
+| 2 | 🔴 高 | 过期 Token 被 JwtFilter 放行（安全漏洞） | `JwtFilter.java`, `JwtService.java` | 新增 `parseTokenClaims()` 抛出异常；Filter 改用 try-catch 捕获 `ExpiredJwtException` 返回 401 |
+| 3 | 🔴 高 | 数据源密码（`pass` 字段）暴露于 API 响应 | `EtlSource.java`, `DbConnectDto.java`, `SourceController.java`, `EtlTargetService.java`, `AddSource.vue`, `source-service.ts` | 哨兵值方案：序列化始终返回 `**UNCHANGED**`；保存时若收到哨兵则从 DB 取原密码；`testConnect` 附带 `sourceId`，哨兵时从 DB 解析真实密码 |
+| 4/5 | 🔴 高 | CORS 配置矛盾 + httpBasic/formLogin 未关闭 | `SecurityConfiguration.java` | `cors(withDefaults())` 替换 `cors(disable)`；`allowedOrigins` 改为可配置属性；disable httpBasic/formLogin |
+| 6 | 🔴 高 | 全局异常处理器泄露原始错误信息（SQL/路径等） | `GlobalExceptionHandler.java` | 兜底 handler 返回通用 `"Internal server error"`，原始信息只写日志 |
+| 7 | 🔴 高 | 登录失败返回 HTTP 200（应为 401） | `AuthController.java` | 改为 `ResponseEntity<>` 返回，失败时正确设置 HTTP 401 |
+| 11 | 🟡 中 | `ObjectMapper` 在每次请求中重新实例化 | `CustomAuthenticationEntryPoint.java`, `CustomAccessDeniedHandler.java` | 添加 `@Component`，注入 Spring 托管的共享 `ObjectMapper` bean |
+| 14 | 🟡 中 | 缺少 400 参数校验异常处理，导致返回 500 | `GlobalExceptionHandler.java` | 添加 `MethodArgumentNotValidException` 和 `HttpMessageNotReadableException` 处理器 |
+| 15 | 🟡 中 | `AuthRequestDTO` 无参数校验注解 | `AuthRequestDTO.java`, `AuthController.java` | 添加 `@NotBlank`；Controller 方法加 `@Valid` |
+| 17 | 🟡 中 | `UserAdminService.listUsers()` N+1 查询（2N+1 次 DB 调用） | `UserAdminService.java` | 改为单次 `LEFT JOIN` 查询，使用 `ResultSetExtractor` 聚合结果 |
+| 21 | 🟡 中 | `restartQueueMonitor()` 每次调用都累积新调度任务 | `TaskQueueManagerV2Impl.java` | 维护 `listenFuture`/`pollFuture`/`recoverFuture` 字段，restart 前先 cancel |
+| 23 | 🟡 中 | `URLClassLoader` 在 Hive 重连时泄漏（Metaspace OOM 风险） | `TargetServiceWithHiveImpl.java` | 保存 classloader 到字段，re-init 时关闭旧实例，`@PreDestroy` 时释放 |
+
+## 未修复项（中低优先级）
+
+| # | 问题 | 建议 |
+|---|------|------|
+| 8 | Controller 直接注入 Repository（AlertController、TableController、MonitorController） | 添加 Service 层封装 |
+| 9 | JPA 实体直接作为 API 请求/响应体（EtlTable、EtlTarget） | 创建对应 DTO |
+| 10 | `@Data @Getter @Setter` 冗余 Lombok 注解 | 保留 `@Data` 即可 |
+| 12 | `LogController` 过滤参数（q、status、sortField、sortOrder）声明但未使用 | 实现过滤逻辑 |
+| 13 | `TableController.listTableViews()` 返回空列表（死代码） | 删除或实现 |
+| 16 | 硬编码 `ZoneOffset.ofHours(8)` | 改为读取系统时区或配置 |
+| 18 | `pageSize=-1` 时使用 `Integer.MAX_VALUE`（OOM 风险） | 设置合理上限（如 10000） |
+| 19 | `SourceController` 使用 `DriverManager.getConnection()` 无连接池/超时 | 加超时限制或连接池 |
+| 20 | 租约续期回调每次都查数据库 `getTable()` | 缓存结果，减少 DB 访问 |
+| 22 | `listenLoop` 异常后无自动重启机制 | 添加异常捕获 + 延迟重启逻辑 |
+| 24 | `Constants.SQL_RESERVED_KEYWORDS` 为 `volatile Set`，写操作非原子 | 改为 `CopyOnWriteArraySet` 或加锁 |
+| 25 | `CollectionScheduler` lambda 捕获 `EtlSource` 快照，数据可能过时 | 改为每次执行时重新查询 |


### PR DESCRIPTION
Security:
- Externalize JWT secret via jwt.secret config property (override with JWT_SECRET env var)
- Fix JwtFilter: use parseTokenClaims() which throws on expiry instead of silently returning null, preventing expired tokens from being treated as anonymous requests
- Add @JsonIgnore to EtlSource.pass to prevent DB passwords leaking in API responses
- Fix CORS config: replace cors(disable) with cors(withDefaults()), make allowed origins configurable via cors.allowed-origins property
- Disable httpBasic and formLogin (unnecessary for a JWT-only API)
- GlobalExceptionHandler: return generic 'Internal server error' instead of ex.getMessage() to avoid leaking table names, SQL snippets, or file paths
- CustomAuthenticationEntryPoint/CustomAccessDeniedHandler: register as @Component and inject shared ObjectMapper bean instead of creating new instances per request

API correctness:
- AuthController.login: return ResponseEntity with proper HTTP 401 status on failure
- AuthRequestDTO: add @NotBlank validation; add @Valid to controller method
- GlobalExceptionHandler: add handlers for MethodArgumentNotValidException (400) and HttpMessageNotReadableException (400) to avoid returning 500 for bad requests

Performance:
- UserAdminService.listUsers: replace N+1 queries (1 + N×2 DB calls) with a single LEFT JOIN query across users and authorities tables

Concurrency:
- TaskQueueManagerV2Impl: maintain ScheduledFuture references (listenFuture, pollFuture, recoverFuture) and cancel them before re-submitting on restartQueueMonitor/startQueueMonitor, preventing unbounded task accumulation on repeated restarts
- TargetServiceWithHiveImpl: store URLClassLoader in hiveClassLoader field; close old classloader on re-initialization and in @PreDestroy to prevent Metaspace OOM