### PR TITLE
feat: migrate task scheduling to master-worker dispatch model

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/controller/SystemFlagController.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/controller/SystemFlagController.java
@@ -1,6 +1,6 @@
 package com.wgzhao.addax.admin.controller;
 
-import com.wgzhao.addax.admin.redis.RedisLockService;
+import com.wgzhao.addax.admin.service.TaskQueueManager;
 import com.wgzhao.addax.admin.service.TaskService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/system")
 public class SystemFlagController
 {
-    private final RedisLockService redisLockService;
+    private final TaskQueueManager queueManager;
     private final TaskService taskService;
 
     @GetMapping("/refresh/status")
     public RefreshStatus status()
     {
-        boolean inProgress = redisLockService.isRefreshInProgress();
+        boolean inProgress = queueManager.isRefreshing();
         return new RefreshStatus(inProgress, inProgress ? "刷新进行中" : "空闲");
     }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/redis/MasterElectionService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/redis/MasterElectionService.java
@@ -1,0 +1,227 @@
+package com.wgzhao.addax.admin.redis;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Master election via Redis NX lock.
+ *
+ * Every node tries to acquire/renew "addax:master:lock" every RENEW_INTERVAL_SECONDS.
+ * The node holding the lock is master. TTL is 30s; if the master crashes, another
+ * node wins within 30s (the next RENEW_INTERVAL_SECONDS tick).
+ *
+ * Callbacks (onBecameMaster / onLostMaster) are invoked synchronously on the
+ * election thread — keep them non-blocking.
+ */
+@Service
+@Slf4j
+public class MasterElectionService
+{
+    public static final String MASTER_LOCK_KEY = "addax:master:lock";
+    private static final int LOCK_TTL_SECONDS = 30;
+    private static final int RENEW_INTERVAL_SECONDS = 10;
+
+    // SET key value XX EX ttl — renew only if we already own the lock (value matches)
+    private static final DefaultRedisScript<String> RENEW_SCRIPT = new DefaultRedisScript<>(
+        "if redis.call('get', KEYS[1]) == ARGV[1] then " +
+        "  redis.call('expire', KEYS[1], ARGV[2]); return 'OK' " +
+        "else return nil end",
+        String.class
+    );
+
+    private final StringRedisTemplate redisTemplate;
+    private final String instanceId;
+
+    private volatile boolean master = false;
+    private final ScheduledExecutorService electionScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "master-election");
+        t.setDaemon(true);
+        return t;
+    });
+    private volatile ScheduledFuture<?> electionFuture;
+
+    private final List<Runnable> onBecameMasterCallbacks = new CopyOnWriteArrayList<>();
+    private final List<Runnable> onLostMasterCallbacks = new CopyOnWriteArrayList<>();
+
+    public MasterElectionService(StringRedisTemplate redisTemplate)
+    {
+        this.redisTemplate = redisTemplate;
+        this.instanceId = resolveInstanceId();
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        electionFuture = electionScheduler.scheduleWithFixedDelay(
+            this::tryElect,
+            0, RENEW_INTERVAL_SECONDS, TimeUnit.SECONDS
+        );
+        log.info("Master election started, instanceId={}", instanceId);
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        if (electionFuture != null) {
+            electionFuture.cancel(false);
+        }
+        electionScheduler.shutdownNow();
+        // Release lock if we are master so a new master can be elected faster
+        if (master) {
+            releaseMasterLock();
+        }
+    }
+
+    public boolean isMaster()
+    {
+        return master;
+    }
+
+    public String getInstanceId()
+    {
+        return instanceId;
+    }
+
+    /** Returns the instanceId of the current master, or null if no master is elected. */
+    public String getMasterInstanceId()
+    {
+        try {
+            return redisTemplate.opsForValue().get(MASTER_LOCK_KEY);
+        }
+        catch (Exception e) {
+            log.warn("Failed to read master lock key", e);
+            return null;
+        }
+    }
+
+    /** Register a callback invoked when this node becomes master. */
+    public void onBecameMaster(Runnable callback)
+    {
+        onBecameMasterCallbacks.add(callback);
+    }
+
+    /** Register a callback invoked when this node loses the master role. */
+    public void onLostMaster(Runnable callback)
+    {
+        onLostMasterCallbacks.add(callback);
+    }
+
+    // ---- internal ----
+
+    private void tryElect()
+    {
+        try {
+            if (master) {
+                renewOrLose();
+            }
+            else {
+                tryAcquire();
+            }
+        }
+        catch (Exception e) {
+            log.error("Master election tick failed", e);
+            if (master) {
+                // Assume we lost master on Redis error to prevent split-brain
+                transitionToWorker();
+            }
+        }
+    }
+
+    private void tryAcquire()
+    {
+        Boolean acquired = redisTemplate.opsForValue()
+            .setIfAbsent(MASTER_LOCK_KEY, instanceId, Duration.ofSeconds(LOCK_TTL_SECONDS));
+        if (Boolean.TRUE.equals(acquired)) {
+            transitionToMaster();
+        }
+    }
+
+    private void renewOrLose()
+    {
+        try {
+            String result = redisTemplate.execute(
+                RENEW_SCRIPT,
+                Collections.singletonList(MASTER_LOCK_KEY),
+                instanceId,
+                String.valueOf(LOCK_TTL_SECONDS)
+            );
+            if (!"OK".equals(result)) {
+                log.warn("Master lock renewal failed (lock stolen or expired), stepping down");
+                transitionToWorker();
+            }
+        }
+        catch (Exception e) {
+            log.error("Redis error during master renewal, stepping down", e);
+            transitionToWorker();
+        }
+    }
+
+    private void releaseMasterLock()
+    {
+        try {
+            // Only delete if we still own it
+            DefaultRedisScript<Long> releaseScript = new DefaultRedisScript<>(
+                "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+                Long.class
+            );
+            redisTemplate.execute(releaseScript, Collections.singletonList(MASTER_LOCK_KEY), instanceId);
+        }
+        catch (Exception e) {
+            log.warn("Failed to release master lock on shutdown", e);
+        }
+    }
+
+    private void transitionToMaster()
+    {
+        master = true;
+        log.info("*** This node became MASTER: instanceId={} ***", instanceId);
+        for (Runnable cb : onBecameMasterCallbacks) {
+            try {
+                cb.run();
+            }
+            catch (Exception e) {
+                log.error("onBecameMaster callback failed", e);
+            }
+        }
+    }
+
+    private void transitionToWorker()
+    {
+        master = false;
+        log.info("*** This node stepped down to WORKER: instanceId={} ***", instanceId);
+        for (Runnable cb : onLostMasterCallbacks) {
+            try {
+                cb.run();
+            }
+            catch (Exception e) {
+                log.error("onLostMaster callback failed", e);
+            }
+        }
+    }
+
+    private static String resolveInstanceId()
+    {
+        try {
+            String host = InetAddress.getLocalHost().getHostName();
+            String pid = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+            return host + "-" + pid;
+        }
+        catch (Exception e) {
+            return java.util.UUID.randomUUID().toString();
+        }
+    }
+}

--- a/backend/src/main/java/com/wgzhao/addax/admin/redis/WorkerHeartbeatService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/redis/WorkerHeartbeatService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +14,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -102,18 +103,17 @@ public class WorkerHeartbeatService
 
     /**
      * Scan all alive worker heartbeats. Called by master during dispatch.
+     * Uses SCAN instead of KEYS to avoid blocking Redis on large keyspaces.
      * Workers whose heartbeat is older than STALE_THRESHOLD_SECONDS are excluded.
      */
     public List<WorkerInfo> getAliveWorkers()
     {
         List<WorkerInfo> result = new ArrayList<>();
-        try {
-            Set<String> keys = redisTemplate.keys(WORKER_KEY_PREFIX + "*");
-            if (keys == null || keys.isEmpty()) {
-                return result;
-            }
-            Instant cutoff = Instant.now().minusSeconds(STALE_THRESHOLD_SECONDS);
-            for (String key : keys) {
+        Instant cutoff = Instant.now().minusSeconds(STALE_THRESHOLD_SECONDS);
+        ScanOptions options = ScanOptions.scanOptions().match(WORKER_KEY_PREFIX + "*").count(100).build();
+        try (Cursor<String> cursor = redisTemplate.scan(options)) {
+            while (cursor.hasNext()) {
+                String key = cursor.next();
                 try {
                     String json = redisTemplate.opsForValue().get(key);
                     if (json == null) continue;

--- a/backend/src/main/java/com/wgzhao/addax/admin/redis/WorkerHeartbeatService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/redis/WorkerHeartbeatService.java
@@ -1,0 +1,185 @@
+package com.wgzhao.addax.admin.redis;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Worker heartbeat service.
+ *
+ * Each node (including the master) publishes a heartbeat to Redis every 15 seconds:
+ *   SET addax:worker:{instanceId} {json} EX 45
+ *
+ * The master reads all alive workers via SCAN "addax:worker:*" when dispatching.
+ *
+ * Workers self-report:
+ *   - availableSlots  = concurrentLimit - currentRunning
+ *   - sourceRunning   = Map<sid, runningCount> for per-source concurrency tracking
+ *   - weight          = node concurrency weight [0.0, 1.0]
+ */
+@Service
+@Slf4j
+public class WorkerHeartbeatService
+{
+    public static final String WORKER_KEY_PREFIX = "addax:worker:";
+    private static final int HEARTBEAT_TTL_SECONDS = 45;
+    private static final int STALE_THRESHOLD_SECONDS = 30;
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final MasterElectionService electionService;
+
+    // References to runtime counters — set by TaskQueueManagerV2Impl after init
+    private volatile int concurrentLimit = 1;
+    private volatile double weight = 1.0;
+    private volatile AtomicInteger runningTaskCount;
+    private volatile ConcurrentHashMap<Integer, AtomicInteger> sourceRunningTaskCount;
+
+    public WorkerHeartbeatService(StringRedisTemplate redisTemplate,
+                                  ObjectMapper objectMapper,
+                                  MasterElectionService electionService)
+    {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+        this.electionService = electionService;
+    }
+
+    /**
+     * Called by TaskQueueManagerV2Impl after its own @PostConstruct to inject live counters.
+     */
+    public void bind(int concurrentLimit,
+                     double weight,
+                     AtomicInteger runningTaskCount,
+                     ConcurrentHashMap<Integer, AtomicInteger> sourceRunningTaskCount)
+    {
+        this.concurrentLimit = concurrentLimit;
+        this.weight = weight;
+        this.runningTaskCount = runningTaskCount;
+        this.sourceRunningTaskCount = sourceRunningTaskCount;
+    }
+
+    /** Publish current heartbeat to Redis. Called every 15s by TaskQueueManagerV2Impl scheduler. */
+    public void publishHeartbeat()
+    {
+        try {
+            WorkerInfo info = buildInfo();
+            String json = objectMapper.writeValueAsString(info);
+            redisTemplate.opsForValue().set(
+                WORKER_KEY_PREFIX + electionService.getInstanceId(),
+                json,
+                Duration.ofSeconds(HEARTBEAT_TTL_SECONDS)
+            );
+            log.debug("Heartbeat published: instanceId={} slots={} running={}",
+                electionService.getInstanceId(), info.availableSlots(), info.running());
+        }
+        catch (Exception e) {
+            log.warn("Failed to publish worker heartbeat", e);
+        }
+    }
+
+    /** Remove own heartbeat from Redis (on shutdown). */
+    public void removeHeartbeat()
+    {
+        try {
+            redisTemplate.delete(WORKER_KEY_PREFIX + electionService.getInstanceId());
+        }
+        catch (Exception e) {
+            log.warn("Failed to remove own heartbeat key", e);
+        }
+    }
+
+    /**
+     * Scan all alive worker heartbeats. Called by master during dispatch.
+     * Workers whose heartbeat is older than STALE_THRESHOLD_SECONDS are excluded.
+     */
+    public List<WorkerInfo> getAliveWorkers()
+    {
+        List<WorkerInfo> result = new ArrayList<>();
+        try {
+            Set<String> keys = redisTemplate.keys(WORKER_KEY_PREFIX + "*");
+            if (keys == null || keys.isEmpty()) {
+                return result;
+            }
+            Instant cutoff = Instant.now().minusSeconds(STALE_THRESHOLD_SECONDS);
+            for (String key : keys) {
+                try {
+                    String json = redisTemplate.opsForValue().get(key);
+                    if (json == null) continue;
+                    WorkerInfo info = objectMapper.readValue(json, WorkerInfo.class);
+                    if (info.lastSeen() != null && info.lastSeen().isAfter(cutoff)) {
+                        result.add(info);
+                    }
+                }
+                catch (Exception e) {
+                    log.debug("Failed to parse worker heartbeat for key={}", key);
+                }
+            }
+        }
+        catch (Exception e) {
+            log.warn("Failed to scan worker heartbeats", e);
+        }
+        return result;
+    }
+
+    private WorkerInfo buildInfo()
+    {
+        int running = runningTaskCount == null ? 0 : runningTaskCount.get();
+        int slots = Math.max(0, concurrentLimit - running);
+
+        ConcurrentHashMap<Integer, AtomicInteger> srcMap = sourceRunningTaskCount;
+        Map<Integer, Integer> sourceRunning = new java.util.HashMap<>();
+        if (srcMap != null) {
+            srcMap.forEach((sid, counter) -> {
+                int cnt = counter.get();
+                if (cnt > 0) sourceRunning.put(sid, cnt);
+            });
+        }
+
+        return new WorkerInfo(
+            electionService.getInstanceId(),
+            resolveHost(),
+            slots,
+            running,
+            concurrentLimit,
+            weight,
+            sourceRunning,
+            Instant.now()
+        );
+    }
+
+    private static String resolveHost()
+    {
+        try {
+            return java.net.InetAddress.getLocalHost().getHostName();
+        }
+        catch (Exception e) {
+            return "unknown";
+        }
+    }
+
+    /**
+     * Immutable snapshot of a worker's state at heartbeat time.
+     */
+    public record WorkerInfo(
+        String instanceId,
+        String host,
+        int availableSlots,
+        int running,
+        int concurrentLimit,
+        double weight,
+        Map<Integer, Integer> sourceRunning,
+        Instant lastSeen
+    ) {}
+}

--- a/backend/src/main/java/com/wgzhao/addax/admin/scheduler/CollectionScheduler.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/scheduler/CollectionScheduler.java
@@ -79,10 +79,7 @@ public class CollectionScheduler
     public void cancelAllScheduledTasks()
     {
         try {
-            List<EtlSource> sources = etlSourceRepo.findByEnabled(true);
-            for (EtlSource source : sources) {
-                taskSchedulerService.cancelTask("source-" + source.getCode());
-            }
+            taskSchedulerService.cancelAll();
         }
         catch (Exception e) {
             log.error("Error cancelling all scheduled tasks", e);

--- a/backend/src/main/java/com/wgzhao/addax/admin/scheduler/CollectionScheduler.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/scheduler/CollectionScheduler.java
@@ -1,17 +1,15 @@
 package com.wgzhao.addax.admin.scheduler;
 
 import com.wgzhao.addax.admin.model.EtlSource;
-import com.wgzhao.addax.admin.redis.RedisLockService;
+import com.wgzhao.addax.admin.redis.MasterElectionService;
 import com.wgzhao.addax.admin.repository.EtlSourceRepo;
 import com.wgzhao.addax.admin.service.TaskSchedulerService;
 import com.wgzhao.addax.admin.service.TaskService;
+import jakarta.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -23,12 +21,23 @@ public class CollectionScheduler
     private final TaskSchedulerService taskSchedulerService;
     private final EtlSourceRepo etlSourceRepo;
     private final TaskService taskService;
-    private final RedisLockService redisLockService;
+    private final MasterElectionService electionService;
 
-    @EventListener(ApplicationReadyEvent.class)
-    public void onApplicationReady()
+    @PostConstruct
+    public void init()
     {
-        rescheduleAllTasks();
+        electionService.onBecameMaster(() -> {
+            log.info("Became master — registering all source cron tasks");
+            rescheduleAllTasks();
+        });
+        electionService.onLostMaster(() -> {
+            log.info("Lost master — cancelling all source cron tasks");
+            cancelAllScheduledTasks();
+        });
+        // Guard against the election tick firing before this callback was registered
+        if (electionService.isMaster()) {
+            rescheduleAllTasks();
+        }
     }
 
     public void rescheduleAllTasks()
@@ -51,32 +60,32 @@ public class CollectionScheduler
             log.info("Scheduling task for source {} at {}", source.getCode(), source.getStartAt());
             String cronExpression = convertLocalTimeToCron(source.getStartAt());
             taskSchedulerService.cancelTask(taskId);
+            // Enqueue is idempotent: DB unique constraint prevents duplicate pending/running entries
             Runnable task = () -> {
-                final String lockKey = "collection:source:" + source.getCode() + ":lock";
-                final Duration ttl = Duration.ofSeconds(300);
-                String token = null;
                 try {
-                    token = redisLockService.tryLock(lockKey, ttl);
-                    if (token == null) {
-                        log.info("Could not acquire lock for source {}, skipping this run", source.getCode());
-                        return;
-                    }
-                    // keep existing behavior: enqueue runnable tables for this source
                     taskService.executeTasksForSource(source.getId());
                 }
                 catch (Exception e) {
                     log.error("Error executing scheduled collection for source {}", source.getCode(), e);
-                }
-                finally {
-                    if (token != null) {
-                        redisLockService.release(lockKey, token);
-                    }
                 }
             };
             taskSchedulerService.scheduleTask(taskId, task, cronExpression);
         }
         else {
             taskSchedulerService.cancelTask(taskId);
+        }
+    }
+
+    public void cancelAllScheduledTasks()
+    {
+        try {
+            List<EtlSource> sources = etlSourceRepo.findByEnabled(true);
+            for (EtlSource source : sources) {
+                taskSchedulerService.cancelTask("source-" + source.getCode());
+            }
+        }
+        catch (Exception e) {
+            log.error("Error cancelling all scheduled tasks", e);
         }
     }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/scheduler/SchemaRefreshScheduler.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/scheduler/SchemaRefreshScheduler.java
@@ -1,7 +1,6 @@
 package com.wgzhao.addax.admin.scheduler;
 
-import com.wgzhao.addax.admin.common.Constants;
-import com.wgzhao.addax.admin.redis.RedisLockService;
+import com.wgzhao.addax.admin.redis.MasterElectionService;
 import com.wgzhao.addax.admin.service.DictService;
 import com.wgzhao.addax.admin.service.TaskService;
 import jakarta.annotation.PostConstruct;
@@ -12,16 +11,11 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.time.LocalTime;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
- * 每天在切日时间触发一次，进行表结构刷新。
+ * 每天在切日时间触发一次，进行表结构刷新。仅 master 节点注册定时任务；failover 后新 master 重新注册。
  */
 @Component
 @Slf4j
@@ -29,46 +23,49 @@ import java.util.concurrent.TimeUnit;
 public class SchemaRefreshScheduler
     implements DisposableBean
 {
-    // Lock TTL and renewal interval
-    private static final Duration LOCK_TTL = Duration.ofSeconds(600);
-    private static final Duration LOCK_RENEW_INTERVAL = Duration.ofSeconds(60);
     private final TaskScheduler taskScheduler;
     private final DictService dictService;
     private final TaskService taskService;
-    private final RedisLockService redisLockService;
-    // Shared renewer thread to avoid creating one per run
-    private final ScheduledExecutorService renewer = Executors.newSingleThreadScheduledExecutor(r -> {
-        Thread t = new Thread(r, "schema-refresh-lock-renewer");
-        t.setDaemon(true);
-        return t;
-    });
+    private final MasterElectionService electionService;
+
     private volatile ScheduledFuture<?> scheduledFuture;
 
     @PostConstruct
     public void init()
     {
-        // Always schedule locally; actual execution is guarded by Redis lock so only one node will run.
-        log.info("Initializing SchemaRefreshScheduler and scheduling local trigger");
-        scheduleInternal();
+        electionService.onBecameMaster(() -> {
+            log.info("Became master — registering schema refresh cron");
+            scheduleInternal();
+        });
+        electionService.onLostMaster(() -> {
+            log.info("Lost master — cancelling schema refresh cron");
+            cancelInternal();
+        });
+        // Guard against election tick firing before this @PostConstruct runs
+        if (electionService.isMaster()) {
+            scheduleInternal();
+        }
     }
 
-    private void scheduleInternal()
+    private synchronized void scheduleInternal()
     {
         LocalTime switchTime = dictService.getSwitchTimeAsTime();
         String cron = toCron(switchTime);
         log.info("Scheduling schema refresh at {} (cron: {})", switchTime, cron);
-        // 先取消已有任务，避免重复
         cancelInternal();
         scheduledFuture = taskScheduler.schedule(this::runRefresh, new CronTrigger(cron));
     }
 
     /**
-     * Public API for controllers/services: reschedule the local timer after SWITCH_TIME is changed.
-     *
-     * This method is safe to call multiple times.
+     * Public API for controllers/services: reschedule after SWITCH_TIME is changed.
+     * No-op on worker nodes.
      */
     public synchronized void reschedule()
     {
+        if (!electionService.isMaster()) {
+            log.debug("reschedule() ignored on non-master node");
+            return;
+        }
         log.info("Rescheduling schema refresh trigger due to switch time update");
         scheduleInternal();
     }
@@ -84,66 +81,18 @@ public class SchemaRefreshScheduler
 
     private String toCron(LocalTime time)
     {
-        // cron format: second minute hour day-of-month month day-of-week
         return String.format("0 %d %d * * *", time.getMinute(), time.getHour());
     }
 
     public void runRefresh()
     {
         log.info("Schema refresh triggered");
-
-        final String lockKey = Constants.SCHEMA_REFRESH_LOCK_KEY;
-        String token = null;
-
-        Future<?> renewTaskFuture = null;
-
         try {
-            token = redisLockService.tryLock(lockKey, LOCK_TTL);
-            if (token == null) {
-                log.info("Could not acquire redis lock {}, another node is running refresh, skip", lockKey);
-                return;
-            }
-
-            final String localToken = token;
-            renewTaskFuture = renewer.scheduleAtFixedRate(() -> {
-                try {
-                    boolean ok = redisLockService.extend(lockKey, localToken, LOCK_TTL);
-                    if (!ok) {
-                        log.warn("Failed to renew redis lock {} with token {}", lockKey, localToken);
-                    }
-                }
-                catch (Exception e) {
-                    log.warn("Exception while renewing redis lock {}: {}", lockKey, e.getMessage());
-                }
-            }, LOCK_RENEW_INTERVAL.toMillis(), LOCK_RENEW_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
-
-            try {
-                taskService.updateParams();
-                log.info("Schema refresh finished successfully");
-            }
-            catch (Exception e) {
-                log.error("Schema refresh failed", e);
-            }
+            taskService.updateParams();
+            log.info("Schema refresh finished successfully");
         }
-        catch (Exception ex) {
-            log.error("Error while attempting schema refresh or acquiring lock", ex);
-        }
-        finally {
-            // stop renew task
-            if (renewTaskFuture != null) {
-                try {
-                    renewTaskFuture.cancel(true);
-                }
-                catch (Exception ignored) {
-                }
-            }
-
-            if (token != null) {
-                boolean released = redisLockService.release(lockKey, token);
-                if (!released) {
-                    log.warn("Failed to release redis lock {} with token {} - will expire by TTL", lockKey, token);
-                }
-            }
+        catch (Exception e) {
+            log.error("Schema refresh failed", e);
         }
     }
 
@@ -151,10 +100,5 @@ public class SchemaRefreshScheduler
     public void destroy()
     {
         cancelInternal();
-        try {
-            renewer.shutdownNow();
-        }
-        catch (Exception ignored) {
-        }
     }
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/scheduler/TableOverrideScheduler.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/scheduler/TableOverrideScheduler.java
@@ -5,7 +5,7 @@ import com.wgzhao.addax.admin.redis.MasterElectionService;
 import com.wgzhao.addax.admin.service.TableService;
 import com.wgzhao.addax.admin.service.TaskQueueManager;
 import jakarta.annotation.PostConstruct;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
@@ -26,7 +26,7 @@ import java.util.concurrent.ScheduledFuture;
  */
 @Component
 @Slf4j
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TableOverrideScheduler
 {
     private final TableService tableService;

--- a/backend/src/main/java/com/wgzhao/addax/admin/scheduler/TableOverrideScheduler.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/scheduler/TableOverrideScheduler.java
@@ -1,26 +1,28 @@
 package com.wgzhao.addax.admin.scheduler;
 
 import com.wgzhao.addax.admin.model.EtlTable;
-import com.wgzhao.addax.admin.redis.RedisLockService;
+import com.wgzhao.addax.admin.redis.MasterElectionService;
 import com.wgzhao.addax.admin.service.TableService;
 import com.wgzhao.addax.admin.service.TaskQueueManager;
+import jakarta.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.concurrent.ScheduledFuture;
 
 /**
  * 表级覆盖调度器（table-level schedule override）。
  *
  * 说明：
  * - 仅处理 etl_table.start_at 非空的表（覆盖调度），且命中当前分钟时将其入队。
- * - 不负责执行，不做并发控制；执行侧并发由 TaskQueueManagerV2Impl 的 permit 控制。
- * - 使用 Redis 短锁避免多节点重复扫描导致重复入队尝试。
+ * - 不负责执行，不做并发控制；执行侧并发由 TaskQueueManagerV2Impl 控制。
+ * - 仅在 master 节点上注册，发生 failover 时新 master 重新注册。
  */
 @Component
 @Slf4j
@@ -29,7 +31,8 @@ public class TableOverrideScheduler
 {
     private final TableService tableService;
     private final TaskQueueManager queueManager;
-    private final RedisLockService redisLockService;
+    private final MasterElectionService electionService;
+    private final TaskScheduler taskScheduler;
 
     /**
      * 覆盖调度补偿窗口（分钟）。
@@ -39,29 +42,49 @@ public class TableOverrideScheduler
      */
     private static int OVERRIDE_MISFIRE_WINDOW_MINUTES = 2;
 
-    @Scheduled(cron = "0 * * * * ?")
-    public void tick()
+    private volatile ScheduledFuture<?> overrideFuture;
+
+    @PostConstruct
+    public void init()
+    {
+        electionService.onBecameMaster(() -> {
+            log.info("Became master — registering table-override cron tick");
+            register();
+        });
+        electionService.onLostMaster(() -> {
+            log.info("Lost master — cancelling table-override cron tick");
+            cancel();
+        });
+        if (electionService.isMaster()) {
+            register();
+        }
+    }
+
+    private synchronized void register()
+    {
+        cancel();
+        overrideFuture = taskScheduler.schedule(this::tick, new CronTrigger("0 * * * * ?"));
+    }
+
+    private synchronized void cancel()
+    {
+        if (overrideFuture != null) {
+            overrideFuture.cancel(false);
+            overrideFuture = null;
+        }
+    }
+
+    private void tick()
     {
         LocalTime nowMinute = LocalTime.now().truncatedTo(ChronoUnit.MINUTES);
         LocalTime from = nowMinute.minusMinutes(OVERRIDE_MISFIRE_WINDOW_MINUTES);
 
-        final String lockKey = "collection:table-override:tick:lock";
-        final Duration ttl = Duration.ofSeconds(50);
-        String token = null;
-
         try {
-            token = redisLockService.tryLock(lockKey, ttl);
-            if (token == null) {
-                return;
-            }
-
             int enqueued = 0;
 
             // Handle midnight wrap: if from is after nowMinute, it means we crossed 00:00.
             if (from.isAfter(nowMinute)) {
-                // [00:00, now]
                 enqueued += enqueueRange(LocalTime.MIDNIGHT, nowMinute);
-                // [from, 23:59]
                 enqueued += enqueueRange(from, LocalTime.of(23, 59));
             }
             else {
@@ -73,15 +96,7 @@ public class TableOverrideScheduler
             }
         }
         catch (Exception e) {
-            log.error("Error in TableOverrideScheduler", e);
-        }
-        finally {
-            if (token != null) {
-                boolean released = redisLockService.release(lockKey, token);
-                if (!released) {
-                    log.warn("Failed to release lock {} (token={})", lockKey, token);
-                }
-            }
+            log.error("Error in TableOverrideScheduler tick", e);
         }
     }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java
@@ -172,6 +172,33 @@ public class EtlJobQueueService
         return jdbcTemplate.update(sql);
     }
 
+    /**
+     * Master-mode: atomically claim the next pending job and assign it to a specific worker instance.
+     * Semantically identical to claimNext() but claimed_by is the target worker, not the local node.
+     */
+    @Transactional
+    public Optional<EtlJobQueue> assignToWorker(String targetInstanceId, int leaseSeconds)
+    {
+        String sql = """
+            WITH cte AS (
+                SELECT id
+                FROM public.etl_job_queue
+                WHERE status='pending' AND available_at <= now()
+                ORDER BY priority, available_at
+                FOR UPDATE SKIP LOCKED
+                LIMIT 1
+            )
+            UPDATE public.etl_job_queue q
+            SET status='running', claimed_by=?, claimed_at=now(), lease_until=now() + ?::interval, attempts=attempts+1
+            FROM cte
+            WHERE q.id = cte.id
+            RETURNING q.*
+            """;
+        String leaseInterval = leaseSeconds + " seconds";
+        List<EtlJobQueue> list = jdbcTemplate.query(sql, JOB_ROW_MAPPER, targetInstanceId, leaseInterval);
+        return list.isEmpty() ? Optional.empty() : Optional.of(list.getFirst());
+    }
+
     // Renew lease for a running, claimed job. Returns true if the lease was renewed.
     @Transactional
     public boolean renewLease(long jobId, String instanceId, int leaseSeconds)

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/TableService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/TableService.java
@@ -5,7 +5,6 @@ import com.wgzhao.addax.admin.dto.BatchTableStatusDto;
 import com.wgzhao.addax.admin.dto.TaskResultDto;
 import com.wgzhao.addax.admin.model.EtlTable;
 import com.wgzhao.addax.admin.model.VwEtlTableWithSource;
-import com.wgzhao.addax.admin.redis.RedisLockService;
 import com.wgzhao.addax.admin.repository.EtlTableRepo;
 import com.wgzhao.addax.admin.repository.VwEtlTableWithSourceRepo;
 import com.wgzhao.addax.admin.utils.QueryUtil;
@@ -43,7 +42,6 @@ public class TableService
     private final EtlJourService jourService;
     private final VwEtlTableWithSourceRepo vwEtlTableWithSourceRepo;
     private final TargetService targetService;
-    private final RedisLockService redisLockService;
     private final SystemConfigService configService;
     private final UserNotificationService userNotificationService;
     private final EntityManager entityManager;
@@ -219,11 +217,6 @@ public class TableService
             }
             catch (Exception e) {
                 log.error("Failed to refresh resources for table {}", table.getId(), e);
-            }
-            // also check system flag to decide whether to continue (if flag cleared externally)
-            if (!redisLockService.isRefreshInProgress()) {
-                log.info("Global schema refresh flag cleared, aborting refreshAllTableResources at table {}", table.getId());
-                break;
             }
         }
     }
@@ -429,12 +422,6 @@ public class TableService
      */
     public List<EtlTable> getRunnableTasks()
     {
-        // If schema refresh in progress, do not return runnable tasks to avoid starting new tasks
-        if (redisLockService.isRefreshInProgress()) {
-            log.info("Schema refresh in progress, returning no runnable tasks");
-            return List.of();
-        }
-
         LocalTime switchTime = dictService.getSwitchTimeAsTime();
         LocalTime currentTime = LocalDateTime.now().toLocalTime();
         boolean checkTime = currentTime.isAfter(switchTime);
@@ -449,11 +436,6 @@ public class TableService
      */
     public List<EtlTable> getRunnableTasks(int sourceId)
     {
-        if (redisLockService.isRefreshInProgress()) {
-            log.info("Schema refresh in progress, returning no runnable tasks for source {}", sourceId);
-            return List.of();
-        }
-
         LocalTime switchTime = dictService.getSwitchTimeAsTime();
         LocalTime currentTime = LocalDateTime.now().toLocalTime();
         boolean checkTime = currentTime.isAfter(switchTime);
@@ -468,9 +450,6 @@ public class TableService
      */
     public List<EtlTable> getRunnableInheritedTasksBySource(int sourceId)
     {
-        if (redisLockService.isRefreshInProgress()) {
-            return List.of();
-        }
         return etlTableRepo.findRunnableInheritedTasksBySource(sourceId);
     }
 
@@ -479,17 +458,11 @@ public class TableService
      */
     public List<EtlTable> getRunnableOverrideTasksByStartAt(LocalTime startAt)
     {
-        if (redisLockService.isRefreshInProgress()) {
-            return List.of();
-        }
         return etlTableRepo.findRunnableOverrideTasksByStartAt(startAt);
     }
 
     public List<EtlTable> getRunnableOverrideTasksBetween(LocalTime from, LocalTime to)
     {
-        if (redisLockService.isRefreshInProgress()) {
-            return List.of();
-        }
         return etlTableRepo.findRunnableOverrideTasksBetween(from, to);
     }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/TaskQueueManager.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/TaskQueueManager.java
@@ -29,6 +29,15 @@ public interface TaskQueueManager
         return addTaskToQueue(tableId);
     }
 
+    /**
+     * Returns true while schema refresh is in progress (queue monitor stopped).
+     * Use this instead of checking the Redis schema refresh lock key, which is no longer written.
+     */
+    default boolean isRefreshing()
+    {
+        return false;
+    }
+
     int clearQueue();
 
     Map<String, Object> getQueueStatus();

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/TaskService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/TaskService.java
@@ -333,7 +333,7 @@ public class TaskService
             where status = 'running'
             ) q
             on t.id = q.tid and q.qrn = 1
-            where rn = 1
+            where rn = 1 or rn is null
             order by id
             """;
         List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql, defaultTakeSecs);

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/TaskService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/TaskService.java
@@ -333,7 +333,8 @@ public class TaskService
             where status = 'running'
             ) q
             on t.id = q.tid and q.qrn = 1
-            where rn = 1 or rn is null
+            where t.status in ('R', 'W')
+              and (rn = 1 or rn is null)
             order by id
             """;
         List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql, defaultTakeSecs);

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/TaskService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/TaskService.java
@@ -3,7 +3,6 @@ package com.wgzhao.addax.admin.service;
 import com.wgzhao.addax.admin.dto.TaskResultDto;
 import com.wgzhao.addax.admin.model.EtlJour;
 import com.wgzhao.addax.admin.model.EtlTable;
-import com.wgzhao.addax.admin.redis.RedisLockService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,7 +37,6 @@ public class TaskService
     private final JdbcTemplate jdbcTemplate;
     private final EtlJourService jourService;
     private final SystemConfigService configService;
-    private final RedisLockService redisLockService;
     private final ExecutionManager executionManager;
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper;
@@ -211,15 +209,9 @@ public class TaskService
 
     public TaskResultDto submitTask(long tableId)
     {
-        // 如果 schema 刷新中（由 redis 锁控制），拒绝提交
-        try {
-            if (redisLockService != null && redisLockService.isRefreshInProgress()) {
-                log.info("当前正在更新参数/刷新表结构，拒绝直接提交任务：tableId={}", tableId);
-                return TaskResultDto.failure("正在刷新表结构，暂时无法提交任务", 0);
-            }
-        }
-        catch (Exception e) {
-            log.warn("检查 schema 刷新锁失败，继续按 DB flag 逻辑处理", e);
+        if (queueManager.isRefreshing()) {
+            log.info("当前正在更新参数/刷新表结构，拒绝直接提交任务：tableId={}", tableId);
+            return TaskResultDto.failure("正在刷新表结构，暂时无法提交任务", 0);
         }
         if (queueManager.addTaskToQueue(tableId)) {
             return TaskResultDto.success("任务已提交到队列", 0);
@@ -231,15 +223,9 @@ public class TaskService
 
     public TaskResultDto submitTask(long tableId, String username)
     {
-        // 如果 schema 刷新中（由 redis 锁控制），拒绝提交
-        try {
-            if (redisLockService != null && redisLockService.isRefreshInProgress()) {
-                log.info("当前正在更新参数/刷新表结构，拒绝直接提交任务：tableId={}", tableId);
-                return TaskResultDto.failure("正在刷新表结构，暂时无法提交任务", 0);
-            }
-        }
-        catch (Exception e) {
-            log.warn("检查 schema 刷新锁失败，继续按 DB flag 逻辑处理", e);
+        if (queueManager.isRefreshing()) {
+            log.info("当前正在更新参数/刷新表结构，拒绝直接提交任务：tableId={}", tableId);
+            return TaskResultDto.failure("正在刷新表结构，暂时无法提交任务", 0);
         }
 
         String payload = null;

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -641,14 +641,9 @@ public class TaskQueueManagerV2Impl
 
     public boolean addTaskToQueue(@NonNull EtlTable etlTable)
     {
-        try {
-            if (redisLockService != null && redisLockService.isLocked(SCHEMA_REFRESH_LOCK_KEY)) {
-                log.info("Schema refresh in progress, rejecting task {} into queue", etlTable.getId());
-                return false;
-            }
-        }
-        catch (Exception e) {
-            log.warn("Failed to check schema refresh lock, proceeding with enqueue", e);
+        if (!running) {
+            log.info("Schema refresh in progress, rejecting task {} into queue", etlTable.getId());
+            return false;
         }
         LocalDate bizDate = LocalDate.parse(configService.getBizDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
         return jobQueueService.enqueue(etlTable, bizDate, 100) > 0;
@@ -657,14 +652,9 @@ public class TaskQueueManagerV2Impl
     @Override
     public boolean addTaskToQueue(@NonNull EtlTable etlTable, String payload)
     {
-        try {
-            if (redisLockService != null && redisLockService.isLocked(SCHEMA_REFRESH_LOCK_KEY)) {
-                log.info("Schema refresh in progress, rejecting task {} into queue", etlTable.getId());
-                return false;
-            }
-        }
-        catch (Exception e) {
-            log.warn("Failed to check schema refresh lock, proceeding with enqueue", e);
+        if (!running) {
+            log.info("Schema refresh in progress, rejecting task {} into queue", etlTable.getId());
+            return false;
         }
         LocalDate bizDate = LocalDate.parse(configService.getBizDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
         return jobQueueService.enqueue(etlTable, bizDate, 100, payload) > 0;
@@ -686,6 +676,12 @@ public class TaskQueueManagerV2Impl
     public int clearQueue()
     {
         return jobQueueService.clearPending();
+    }
+
+    @Override
+    public boolean isRefreshing()
+    {
+        return !running;
     }
 
     public Map<String, Object> getQueueStatus()

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -1,13 +1,16 @@
 package com.wgzhao.addax.admin.service.impl;
 
 import cn.hutool.core.date.DateUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wgzhao.addax.admin.common.JourKind;
 import com.wgzhao.addax.admin.dto.TaskResultDto;
 import com.wgzhao.addax.admin.model.EtlJobQueue;
 import com.wgzhao.addax.admin.model.EtlJour;
 import com.wgzhao.addax.admin.model.EtlTable;
 import com.wgzhao.addax.admin.model.VwEtlTableWithSource;
+import com.wgzhao.addax.admin.redis.MasterElectionService;
 import com.wgzhao.addax.admin.redis.RedisLockService;
+import com.wgzhao.addax.admin.redis.WorkerHeartbeatService;
 import com.wgzhao.addax.admin.service.AddaxLogService;
 import com.wgzhao.addax.admin.service.AlertService;
 import com.wgzhao.addax.admin.service.DictService;
@@ -27,13 +30,16 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -46,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -64,23 +69,29 @@ import static com.wgzhao.addax.admin.common.Constants.shortSdf;
 import static java.lang.Math.max;
 
 /**
- * 采集任务队列管理器 - 使用 PostgreSQL 持久化队列 + LISTEN/NOTIFY
- * 并发与锁控制从数据库迁移为 Redis
+ * 采集任务队列管理器 - Master/Worker 分配模式
+ *
+ * Master（通过 Redis NX 选举）独占从 DB 队列分配任务，通过 Redis pub/sub 推送给指定 worker。
+ * Worker 订阅 "addax:task:assign:{instanceId}" 频道，收到任务后执行。
+ * 每个节点（含 master）都同时是 worker，通过心跳上报可用 slot 给 master。
  */
 @Component
 @Primary
 @Slf4j
 @RequiredArgsConstructor
 public class TaskQueueManagerV2Impl
-    implements TaskQueueManager
+    implements TaskQueueManager, MessageListener
 {
-    // backoff 策略
+    // Backoff strategy
     private static final int BACKOFF_MIN_SECONDS = 30;
-    private static final int BACKOFF_MAX_SECONDS = 1800; // 30m
+    private static final int BACKOFF_MAX_SECONDS = 1800;
     private static final int BACKOFF_FACTOR = 2;
-    // 轮询间隔 & 租约
+    // Polling interval & lease
     private static final int DEFAULT_POLL_INTERVAL_SECONDS = 3;
-    private static final int DEFAULT_LEASE_SECONDS = 7300; // 2小时 + 5分钟 buffer
+    private static final int DEFAULT_LEASE_SECONDS = 7300;
+    private static final int HEARTBEAT_INTERVAL_SECONDS = 15;
+    // Redis channel for task assignment: master → worker
+    private static final String TASK_ASSIGN_CHANNEL_PREFIX = "addax:task:assign:";
 
     private final DictService dictService;
     private final AddaxLogService addaxLogService;
@@ -95,136 +106,165 @@ public class TaskQueueManagerV2Impl
     private final RedisLockService redisLockService;
     private final ExecutionManager executionManager;
     private final UserNotificationService userNotificationService;
-    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final MasterElectionService electionService;
+    private final WorkerHeartbeatService heartbeatService;
+    private final RedisMessageListenerContainer listenerContainer;
 
-    // 本地并发统计（仅用于快速短期判断/指标）
+    // Local concurrency counters (worker-side)
     private final AtomicInteger runningTaskCount = new AtomicInteger(0);
     private final ConcurrentHashMap<Integer, AtomicInteger> sourceRunningTaskCount = new ConcurrentHashMap<>();
-    // token maps: store redis tokens associated with a jobId
-    private final ConcurrentHashMap<Long, String> jobLockToken = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<Long, String> jobGlobalPermitToken = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<Long, String> jobSourcePermitToken = new ConcurrentHashMap<>();
+
     private final ExecutorService workerPool = Executors.newCachedThreadPool(r -> {
         Thread t = new Thread(r, "etl-worker");
         t.setDaemon(true);
         return t;
     });
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2, r -> {
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3, r -> {
         Thread t = new Thread(r, "etl-scheduler");
         t.setDaemon(true);
         return t;
     });
-    // 在本地任务完成后触发调度的合并标记，避免并发任务完成时重复提交大量 dispatch 任务
+
+    // Coalescing flag to prevent flooding dispatch on concurrent task completions
     private final AtomicBoolean dispatchScheduled = new AtomicBoolean(false);
 
-    // 并发限制 & 入队容量
     private int concurrentLimit;
     private int enqueueCapacity;
     private volatile boolean running = false;
     private String instanceId;
-    // node-level concurrency weight in (0.0,1.0]
     private double concurrencyWeight = 1.0;
 
-    // holds futures for cancellation on restart/stop to prevent task accumulation
     private volatile Future<?> listenFuture;
     private volatile ScheduledFuture<?> pollFuture;
     private volatile ScheduledFuture<?> recoverFuture;
+    private volatile ScheduledFuture<?> heartbeatFuture;
 
     @PostConstruct
     public void init()
     {
         configService.loadConfig();
-        // original concurrent limit from config (before applying weight)
         int originalConcurrentLimit = configService.getConcurrentLimit();
-        // read weight from config service (default 1.0)
         this.concurrencyWeight = configService.getNodeConcurrencyWeight();
-        // apply weight to determine effective concurrent limit (at least 1)
         this.concurrentLimit = Math.max(1, (int) Math.floor(originalConcurrentLimit * this.concurrencyWeight));
         this.enqueueCapacity = configService.getQueueSize();
-        this.instanceId = resolveInstanceId();
+        this.instanceId = electionService.getInstanceId();
+
+        // Bind live counters into heartbeat service so it can report accurate state
+        heartbeatService.bind(this.concurrentLimit, this.concurrencyWeight, runningTaskCount, sourceRunningTaskCount);
+
+        // Subscribe to our personal task-assignment channel (worker side)
+        try {
+            listenerContainer.addMessageListener(this, new ChannelTopic(TASK_ASSIGN_CHANNEL_PREFIX + instanceId));
+            log.info("Subscribed to task assignment channel: {}", TASK_ASSIGN_CHANNEL_PREFIX + instanceId);
+        }
+        catch (Exception e) {
+            log.error("Failed to subscribe to task assignment channel", e);
+        }
+
+        // Register master election callbacks
+        electionService.onBecameMaster(this::onBecameMaster);
+        electionService.onLostMaster(this::onLostMaster);
 
         running = true;
         submitScheduledTasks();
-        log.info("Redis-backed arbitration queue started. originalConcurrentLimit={} weight={} effectiveConcurrentLimit={} enqueueCapacity={} instanceId={} ", originalConcurrentLimit, concurrencyWeight, concurrentLimit, enqueueCapacity, instanceId);
+
+        log.info("Task queue manager started (master-worker mode). originalConcurrentLimit={} weight={} effectiveConcurrentLimit={} enqueueCapacity={} instanceId={}",
+            originalConcurrentLimit, concurrencyWeight, concurrentLimit, enqueueCapacity, instanceId);
     }
 
     private void submitScheduledTasks()
     {
-        // 启动 LISTEN 监听器
         listenFuture = scheduler.submit(this::listenLoop);
-        // 启动定时轮询兜底
         pollFuture = scheduler.scheduleWithFixedDelay(this::pollAndDispatch, 1, DEFAULT_POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
-        // 启动租约回收（仍保留 DB 层回收以保证兼容）
         recoverFuture = scheduler.scheduleWithFixedDelay(this::recoverLeases, 30, 30, TimeUnit.SECONDS);
+        heartbeatFuture = scheduler.scheduleWithFixedDelay(heartbeatService::publishHeartbeat, 2, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
     private void cancelScheduledTasks()
     {
-        if (listenFuture != null) {
-            listenFuture.cancel(true);
-        }
-        if (pollFuture != null) {
-            pollFuture.cancel(false);
-        }
-        if (recoverFuture != null) {
-            recoverFuture.cancel(false);
-        }
+        if (listenFuture != null) listenFuture.cancel(true);
+        if (pollFuture != null) pollFuture.cancel(false);
+        if (recoverFuture != null) recoverFuture.cancel(false);
+        if (heartbeatFuture != null) heartbeatFuture.cancel(false);
     }
 
-    private String resolveInstanceId()
+    // ---- Master election callbacks ----
+
+    private void onBecameMaster()
     {
-        try {
-            String host = InetAddress.getLocalHost().getHostName();
-            String pid = ManagementFactory.getRuntimeMXBean().getName();
-            return host + "-" + pid;
-        }
-        catch (Exception e) {
-            return UUID.randomUUID().toString();
-        }
+        log.info("Became master — starting dispatch loop");
+        // pollAndDispatch will now call masterDispatch() because isMaster() is true
     }
+
+    private void onLostMaster()
+    {
+        log.info("Lost master role — pausing dispatch (workers continue executing current tasks)");
+        // pollAndDispatch will skip masterDispatch() because isMaster() is false
+    }
+
+    // ---- Worker: receive task assignment via Redis pub/sub ----
 
     /**
-     * 扫描并入队（DB 持久化），遵守容量限制与去重
+     * Called when master publishes a task-assignment message to this node's channel.
+     */
+    @Override
+    public void onMessage(@NonNull Message message, byte[] pattern)
+    {
+        try {
+            String body = new String(message.getBody());
+            EtlJobQueue job = objectMapper.readValue(body, EtlJobQueue.class);
+            log.info("Received task assignment: jobId={} tid={}", job.getId(), job.getTid());
+            runningTaskCount.incrementAndGet();
+            EtlTable table = tableService.getTable(job.getTid());
+            if (table != null) {
+                VwEtlTableWithSource source = tableService.getTableView(table.getId());
+                if (source != null && source.getMaxConcurrency() != null && source.getMaxConcurrency() > 0) {
+                    sourceRunningTaskCount.computeIfAbsent(table.getSid(), k -> new AtomicInteger(0)).incrementAndGet();
+                }
+            }
+            workerPool.submit(() -> executeClaimedJob(job));
+        }
+        catch (Exception e) {
+            log.error("Failed to handle task assignment message", e);
+        }
+    }
+
+    // ---- Master: scan alive workers, assign jobs ----
+
+    /**
+     * scanAndEnqueueEtlTasks: persists runnable tables into DB queue (DB-side, idempotent).
+     * Only one node needs to do this, but it's safe if all do (unique constraint prevents duplicates).
      */
     public void scanAndEnqueueEtlTasks()
     {
         try {
             long pending = jobQueueService.countPending();
             if (pending >= enqueueCapacity) {
-                log.warn("队列已达容量上限: {}/{}，暂停入队", pending, enqueueCapacity);
+                log.warn("Queue capacity reached: {}/{}, skipping enqueue", pending, enqueueCapacity);
                 return;
             }
             List<EtlTable> tasks = tableService.getRunnableTasks();
-            if (tasks.isEmpty()) {
-                return;
-            }
+            if (tasks.isEmpty()) return;
             int room = (int) Math.max(0, enqueueCapacity - pending);
             int enqueued = 0, skipped = 0;
             LocalDate bizDate = LocalDate.parse(configService.getBizDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
             for (EtlTable t : tasks) {
-                if (enqueued >= room) {
-                    skipped += 1;
-                    continue;
-                }
+                if (enqueued >= room) { skipped++; continue; }
                 try {
                     int added = jobQueueService.enqueue(t, bizDate, 100);
-                    if (added > 0) {
-                        enqueued++;
-                    }
-                    else {
-                        skipped++;
-                    }
+                    if (added > 0) enqueued++; else skipped++;
                 }
                 catch (Exception ex) {
-                    // 可能因为唯一约束冲突等导致无法入队
                     skipped++;
-                    log.debug("入队跳过 tid={}, 原因={} ", t.getId(), ex.getMessage());
+                    log.debug("Enqueue skipped tid={}, reason={}", t.getId(), ex.getMessage());
                 }
             }
-            log.info("入队完成: 成功 {} 个，跳过 {} 个，队列待处理 {}", enqueued, skipped, jobQueueService.countPending());
+            log.info("Enqueue complete: {} added, {} skipped, {} pending in queue", enqueued, skipped, jobQueueService.countPending());
         }
         catch (Exception e) {
-            log.error("扫描并入队失败", e);
+            log.error("scanAndEnqueueEtlTasks failed", e);
             alertService.sendToWeComRobot("扫描采集任务失败: " + e.getMessage());
         }
     }
@@ -239,14 +279,12 @@ public class TaskQueueManagerV2Impl
             org.postgresql.PGConnection pgConn = conn.unwrap(org.postgresql.PGConnection.class);
             while (running) {
                 try {
-                    // 通过发送一条轻量查询来触发通知检查
                     stmt.execute("SELECT 1");
                     org.postgresql.PGNotification[] notes = pgConn.getNotifications();
                     if (notes != null && notes.length > 0) {
-                        log.debug("收到 {} 条通知", notes.length);
-                        // 每条通知尝试触发一次拉取与分发
+                        log.debug("Received {} DB notifications", notes.length);
                         for (org.postgresql.PGNotification ignored : notes) {
-                            dispatchUntilFull();
+                            triggerDispatchAsync();
                         }
                     }
                     TimeUnit.MILLISECONDS.sleep(500);
@@ -256,223 +294,136 @@ public class TaskQueueManagerV2Impl
                     break;
                 }
                 catch (SQLException se) {
-                    log.warn("LISTEN 循环 SQL 异常，将重试", se);
+                    log.warn("LISTEN loop SQL error, will retry", se);
                     TimeUnit.SECONDS.sleep(2);
                 }
             }
         }
         catch (Exception e) {
-            log.error("LISTEN 监听器异常退出", e);
+            log.error("LISTEN listener exited with error", e);
         }
-        log.info("LISTEN 监听器结束");
+        log.info("LISTEN listener stopped");
     }
 
     private void pollAndDispatch()
     {
-        if (!running) {
-            return;
-        }
-        dispatchUntilFull();
-    }
-
-    private void dispatchUntilFull()
-    {
-        // 使用 Redis 全局并发许可和数据源级许可来决定是否真正执行任务
-        while (running && runningTaskCount.get() < concurrentLimit) {
-            Optional<EtlJobQueue> maybe = jobQueueService.claimNext(instanceId, DEFAULT_LEASE_SECONDS);
-            if (maybe.isEmpty()) {
-                return;
-            }
-            EtlJobQueue job = maybe.get();
-            EtlTable table = tableService.getTable(job.getTid());
-            if (table == null) {
-                log.warn("未找到 tid={} 对应的任务信息，跳过该任务", job.getTid());
-                jobQueueService.completeFailure(job.getId(), "任务信息丢失");
-                continue;
-            }
-            VwEtlTableWithSource source = tableService.getTableView(table.getId());
-            Integer maxConcurrency = source.getMaxConcurrency();
-
-            final long jobId = job.getId();
-            final String jobLockKey = "etl:job:" + jobId + ":lock";
-            final Duration jobLockTtl = Duration.ofSeconds(DEFAULT_LEASE_SECONDS);
-
-            // Try to acquire per-job redis lock to ensure only one node proceeds with this job
-            String jtoken = null;
-            try {
-                jtoken = redisLockService.tryLock(jobLockKey, jobLockTtl);
-                if (jtoken == null) {
-                    log.info("Could not acquire redis job lock {} for jobId={}, releasing DB claim", jobLockKey, jobId);
-                    jobQueueService.releaseClaim(job.getId(), 5);
-                    continue;
-                }
-                jobLockToken.put(jobId, jtoken);
-
-                // Try to acquire global permit
-                // Use instance-scoped permit keys so concurrency limits are per-node (not cluster-wide).
-                String globalPermitKey = "concurrent:holders:" + this.instanceId;
-                String globalToken = redisLockService.tryAcquirePermit(globalPermitKey, concurrentLimit, jobLockTtl);
-                if (globalToken == null) {
-                    log.info("Global concurrency limit reached, releasing job {}", jobId);
-                    // cleanup
-                    redisLockService.release(jobLockKey, jtoken);
-                    jobLockToken.remove(jobId);
-                    jobQueueService.releaseClaim(job.getId(), 5);
-                    continue;
-                }
-                jobGlobalPermitToken.put(jobId, globalToken);
-
-                // Try to acquire source-level permit if needed
-                String sourcePermitToken;
-                if (maxConcurrency != null && maxConcurrency > 0) {
-                    // apply node-level weight to per-source concurrency
-                    int effectiveSourceLimit = Math.max(1, (int) Math.floor(maxConcurrency * this.concurrencyWeight));
-                    // scope source permit by instanceId so source.maxConcurrency applies per-node
-                    String sourcePermitKey = "source:holders:" + this.instanceId + ":" + table.getSid();
-                    sourcePermitToken = redisLockService.tryAcquirePermit(sourcePermitKey, effectiveSourceLimit, jobLockTtl);
-                    if (sourcePermitToken == null) {
-                        log.info("Source {} concurrency reached (maxConcurrency={} weight={} effective={}), releasing job {}", source.getCode(), maxConcurrency, this.concurrencyWeight, effectiveSourceLimit, jobId);
-                        // cleanup global and job lock
-                        redisLockService.releasePermit(globalPermitKey, globalToken);
-                        jobGlobalPermitToken.remove(jobId);
-                        redisLockService.release(jobLockKey, jtoken);
-                        jobLockToken.remove(jobId);
-                        jobQueueService.releaseClaim(job.getId(), 5);
-                        // mark waiting
-                        try {
-                            tableService.setWaiting(table);
-                        }
-                        catch (Exception e) {
-                            log.warn("设置任务为 WAITING_COLLECT 失败 tid={}, err={}", table.getId(), e.getMessage());
-                        }
-                        continue;
-                    }
-                    jobSourcePermitToken.put(jobId, sourcePermitToken);
-                }
-
-                // Successfully acquired all required permits; now update local counters and submit
-                int current = runningTaskCount.incrementAndGet();
-                if (maxConcurrency != null && maxConcurrency > 0) {
-                    sourceRunningTaskCount.computeIfAbsent(table.getSid(), k -> new AtomicInteger(0)).incrementAndGet();
-                }
-                log.info("领取任务 jobId={}, tid={}, attempts={}/{}, 当前本地并发 {}/{}, 数据源 {} 并发 {}/{} (weight={})",
-                    job.getId(), job.getTid(), job.getAttempts(), job.getMaxAttempts(),
-                    current, concurrentLimit, source.getCode(),
-                    sourceRunningTaskCount.getOrDefault(table.getSid(), new AtomicInteger(0)).get(),
-                    maxConcurrency == null || maxConcurrency <= 0 ? "无限制" : maxConcurrency,
-                    this.concurrencyWeight);
-
-                workerPool.submit(() -> executeClaimedJob(job));
-            }
-            catch (Exception e) {
-                log.error("Dispatch error for jobId={}", job.getId(), e);
-                // best-effort cleanup
-                if (jtoken != null) {
-                    redisLockService.release(jobLockKey, jtoken);
-                    jobLockToken.remove(jobId);
-                }
-
-                try {
-                    jobQueueService.releaseClaim(job.getId(), 5);
-                }
-                catch (Exception ignored) {
-                }
-            }
+        if (!running) return;
+        if (electionService.isMaster()) {
+            masterDispatch();
         }
     }
 
     /**
-     * 在本地任务完成释放并发槽后，异步触发一次调度。
-     * 使用 dispatchScheduled 进行合并控制，避免并发完成时重复提交大量调度任务。
+     * Master-only: read alive workers, assign pending jobs from DB queue via Redis pub/sub.
+     *
+     * For each worker with available slots, we atomically claim a job (assigned to that worker)
+     * and publish the job JSON to the worker's personal channel. The worker picks it up and executes.
+     *
+     * Source-level concurrency: checked against worker.sourceRunning from the heartbeat.
+     * There is up to HEARTBEAT_INTERVAL_SECONDS staleness — acceptable for this use case.
      */
+    private void masterDispatch()
+    {
+        List<WorkerHeartbeatService.WorkerInfo> workers = heartbeatService.getAliveWorkers();
+        if (workers.isEmpty()) {
+            log.debug("No alive workers found, skipping dispatch");
+            return;
+        }
+
+        for (WorkerHeartbeatService.WorkerInfo worker : workers) {
+            int slots = worker.availableSlots();
+            if (slots <= 0) continue;
+
+            for (int i = 0; i < slots; i++) {
+                // Assign next pending job to this worker
+                Optional<EtlJobQueue> maybe = jobQueueService.assignToWorker(worker.instanceId(), DEFAULT_LEASE_SECONDS);
+                if (maybe.isEmpty()) {
+                    // No more pending jobs
+                    return;
+                }
+                EtlJobQueue job = maybe.get();
+
+                // Check source-level concurrency via worker's heartbeat data
+                EtlTable table = tableService.getTable(job.getTid());
+                if (table != null) {
+                    VwEtlTableWithSource source = tableService.getTableView(table.getId());
+                    if (source != null && source.getMaxConcurrency() != null && source.getMaxConcurrency() > 0) {
+                        int effectiveLimit = Math.max(1, (int) Math.floor(source.getMaxConcurrency() * worker.weight()));
+                        int workerSrcRunning = worker.sourceRunning().getOrDefault(table.getSid(), 0);
+                        if (workerSrcRunning >= effectiveLimit) {
+                            // Source concurrency exceeded for this worker — release and try another worker
+                            log.debug("Source {} concurrency limit reached for worker {}, releasing job {}",
+                                source.getCode(), worker.instanceId(), job.getId());
+                            jobQueueService.releaseClaim(job.getId(), 5);
+                            try { tableService.setWaiting(table); } catch (Exception ignored) {}
+                            break; // move to next worker
+                        }
+                    }
+                }
+
+                // Publish job to worker's channel
+                try {
+                    String assignPayload = objectMapper.writeValueAsString(job);
+                    String channel = TASK_ASSIGN_CHANNEL_PREFIX + worker.instanceId();
+                    stringRedisTemplate.convertAndSend(channel, assignPayload);
+                    log.info("Assigned job {} (tid={}) to worker {}", job.getId(), job.getTid(), worker.instanceId());
+                }
+                catch (Exception e) {
+                    log.error("Failed to publish task assignment for jobId={} to worker={}", job.getId(), worker.instanceId(), e);
+                    // Release the claim so another dispatch cycle can retry
+                    try { jobQueueService.releaseClaim(job.getId(), 5); } catch (Exception ignored) {}
+                }
+            }
+        }
+    }
+
     private void triggerDispatchAsync()
     {
-        if (!running) {
-            return;
-        }
-        // 如果已经有一次待执行的调度在排队/执行中，则不再重复提交
-        if (!dispatchScheduled.compareAndSet(false, true)) {
-            return;
-        }
+        if (!running || !electionService.isMaster()) return;
+        if (!dispatchScheduled.compareAndSet(false, true)) return;
         try {
             scheduler.execute(() -> {
                 try {
-                    // 清除标记，允许后续再次提交调度任务
                     dispatchScheduled.set(false);
-                    // 尽力填满本节点的并发槽位
-                    dispatchUntilFull();
+                    masterDispatch();
                 }
                 catch (Throwable t) {
-                    log.warn("本地触发调度任务执行异常", t);
+                    log.warn("Async dispatch failed", t);
                 }
             });
         }
         catch (Exception e) {
-            // 提交失败时清理标记，避免永远不再触发
             dispatchScheduled.set(false);
-            log.warn("提交本地调度任务失败", e);
+            log.warn("Failed to submit async dispatch", e);
         }
     }
+
+    // ---- Worker: execute an assigned job ----
 
     private void executeClaimedJob(EtlJobQueue job)
     {
         long start = System.currentTimeMillis();
         TaskResultDto taskResultDto = null;
-        // Schedule periodic redis-based lease/permit renewal while this job runs
         ScheduledFuture<?> renewer = null;
         final long jobId = job.getId();
-        final String jobLockKey = "etl:job:" + jobId + ":lock";
-        final Duration jobLockTtl = Duration.ofSeconds(DEFAULT_LEASE_SECONDS);
 
         try {
             int renewInterval = Math.max(30, DEFAULT_LEASE_SECONDS / 3);
             renewer = scheduler.scheduleAtFixedRate(() -> {
                 try {
-                    // renew job lock
-                    String jt = jobLockToken.get(jobId);
-                    if (jt != null) {
-                        boolean ok = redisLockService.extend(jobLockKey, jt, jobLockTtl);
-                        if (!ok) {
-                            log.warn("Failed to renew redis job lock for jobId={}", jobId);
-                        }
-                    }
-                    // renew global permit
-                    String gk = jobGlobalPermitToken.get(jobId);
-                    if (gk != null) {
-                        String globalPermitKey = "concurrent:holders:" + this.instanceId;
-                        boolean ok = redisLockService.extendPermit(globalPermitKey, gk, jobLockTtl);
-                        if (!ok) {
-                            log.warn("Failed to renew global permit for jobId={}", jobId);
-                        }
-                    }
-                    // renew source permit
-                    String sk = jobSourcePermitToken.get(jobId);
-                    if (sk != null) {
-                        String sourcePermitKey = "source:holders:" + this.instanceId + ":" + (tableService.getTable(job.getTid()).getSid());
-                        boolean ok = redisLockService.extendPermit(sourcePermitKey, sk, jobLockTtl);
-                        if (!ok) {
-                            log.warn("Failed to renew source permit for jobId={}", jobId);
-                        }
-                    }
-                    // Still keep DB lease renewal as a fallback for compatibility
-                    try {
-                        boolean dbRenewed = jobQueueService.renewLease(job.getId(), instanceId, DEFAULT_LEASE_SECONDS);
-                        if (!dbRenewed) {
-                            log.warn("DB lease renewal failed jobId={}, instanceId={}", job.getId(), instanceId);
-                        }
-                    }
-                    catch (Exception e) {
-                        log.warn("DB lease renewal exception jobId={}", job.getId(), e);
+                    boolean dbRenewed = jobQueueService.renewLease(job.getId(), instanceId, DEFAULT_LEASE_SECONDS);
+                    if (!dbRenewed) {
+                        log.warn("DB lease renewal failed jobId={}", job.getId());
                     }
                 }
                 catch (Exception e) {
-                    log.warn("Lease/permit renewal exception for jobId={}", jobId, e);
+                    log.warn("Lease renewal exception for jobId={}", jobId, e);
                 }
             }, renewInterval, renewInterval, TimeUnit.SECONDS);
 
             EtlTable task = tableService.getTable(job.getTid());
             if (task == null) {
-                throw new IllegalStateException("任务不存在 tid=" + job.getTid());
+                throw new IllegalStateException("Task not found tid=" + job.getTid());
             }
             taskResultDto = executeEtlTaskWithConcurrencyControl(task, job.getBizDate());
             if (taskResultDto.success()) {
@@ -480,89 +431,39 @@ public class TaskQueueManagerV2Impl
             }
             else {
                 Duration backoff = computeBackoff(job.getAttempts());
-                jobQueueService.failOrReschedule(job, "Addax 退出非0", backoff);
+                jobQueueService.failOrReschedule(job, "Addax non-zero exit", backoff);
             }
         }
         catch (Exception e) {
-            log.error("执行任务失败 jobId={} tid={}", job.getId(), job.getTid(), e);
+            log.error("Task execution failed jobId={} tid={}", job.getId(), job.getTid(), e);
             Duration backoff = computeBackoff(job.getAttempts());
-            try {
-                jobQueueService.failOrReschedule(job, e.getMessage(), backoff);
-            }
-            catch (Exception ignored) {
-            }
+            try { jobQueueService.failOrReschedule(job, e.getMessage(), backoff); } catch (Exception ignored) {}
         }
         finally {
             if (renewer != null) {
-                try {
-                    renewer.cancel(false);
-                }
-                catch (Exception ignored) {
-                }
+                try { renewer.cancel(false); } catch (Exception ignored) {}
             }
-            // 释放本地并发计数
+
             int afterGlobal = runningTaskCount.decrementAndGet();
 
-            // 释放源级并发计数（本地指标）
             EtlTable table = tableService.getTable(job.getTid());
             if (table != null) {
                 VwEtlTableWithSource source = tableService.getTableView(table.getId());
-                if (source != null) {
-                    Integer maxConcurrency = source.getMaxConcurrency();
-                    if (maxConcurrency != null && maxConcurrency > 0) {
-                        sourceRunningTaskCount.computeIfPresent(table.getSid(), (k, v) -> {
-                            int after = v.decrementAndGet();
-                            int effectiveSourceLimit = Math.max(1, (int) Math.floor(maxConcurrency * this.concurrencyWeight));
-                            log.debug("数据源 {} 并发减少为 {}，maxConcurrency={}, weight={}, effective={}", k, after, maxConcurrency, this.concurrencyWeight, effectiveSourceLimit);
-                            return v;
-                        });
-                    }
+                if (source != null && source.getMaxConcurrency() != null && source.getMaxConcurrency() > 0) {
+                    sourceRunningTaskCount.computeIfPresent(table.getSid(), (k, v) -> {
+                        int after = v.decrementAndGet();
+                        log.debug("Source {} concurrency reduced to {} (max={})", k, after, source.getMaxConcurrency());
+                        return v;
+                    });
                 }
             }
 
-            log.debug("jobId={} 完成，耗时 {}s，当前本地并发 {}，当前队列待处理 {}",
+            log.debug("jobId={} done, elapsed={}s, running={}, pending={}",
                 job.getId(), (System.currentTimeMillis() - start) / 1000, afterGlobal, jobQueueService.countPending());
 
-            // Release Redis tokens/permits and cleanup
-            try {
-                String sk = jobSourcePermitToken.remove(jobId);
-                if (sk != null) {
-                    String sourcePermitKey = "source:holders:" + this.instanceId + ":" + (table != null ? table.getSid() : "unknown");
-                    redisLockService.releasePermit(sourcePermitKey, sk);
-                }
-            }
-            catch (Exception e) {
-                log.warn("Failed to release source permit for jobId={}", jobId, e);
-            }
-            try {
-                String gk = jobGlobalPermitToken.remove(jobId);
-                if (gk != null) {
-                    String globalPermitKey = "concurrent:holders:" + this.instanceId;
-                    redisLockService.releasePermit(globalPermitKey, gk);
-                }
-            }
-            catch (Exception e) {
-                log.warn("Failed to release global permit for jobId={}", jobId, e);
-            }
-            try {
-                String jt = jobLockToken.remove(jobId);
-                if (jt != null) {
-                    redisLockService.release(jobLockKey, jt);
-                }
-            }
-            catch (Exception e) {
-                log.warn("Failed to release job lock for jobId={}", jobId, e);
-            }
+            try { notifyJobCompletion(job, taskResultDto); } catch (Exception ignored) {}
 
-            // notify submitter if present
-            try {
-                notifyJobCompletion(job, taskResultDto);
-            }
-            catch (Exception e) {
-                log.debug("Failed to notify job completion for jobId={}", jobId, e);
-            }
-
-            // 完成 DB 层任务后触发调度
+            // Trigger next dispatch cycle on master
             triggerDispatchAsync();
         }
     }
@@ -576,7 +477,6 @@ public class TaskQueueManagerV2Impl
         return Duration.ofSeconds(secs);
     }
 
-    // 重载，允许用队列中的 bizDate 覆盖默认 bizDate
     public TaskResultDto executeEtlTaskWithConcurrencyControl(EtlTable task, LocalDate overrideBizDate)
     {
         long tid = task.getId();
@@ -585,51 +485,41 @@ public class TaskQueueManagerV2Impl
             tableService.setRunning(task);
             boolean result = executeEtlTaskLogic(task, overrideBizDate);
             long duration = max((System.currentTimeMillis() - startTime) / 1000, 0);
-            log.info("采集任务 {}.{}({}) 执行完成，耗时: {}s, 结果: {}", task.getSourceDb(), task.getSourceTable(), tid, duration, result);
+            log.info("Task {}.{}({}) completed, elapsed={}s, result={}", task.getSourceDb(), task.getSourceTable(), tid, duration, result);
             task.setDuration(duration);
             if (result) {
                 tableService.setFinished(task);
-                return TaskResultDto.success("执行成功", duration);
+                return TaskResultDto.success("Success", duration);
             }
             else {
                 tableService.setFailed(task);
-                alertService.sendToWeComRobot(String.format("采集任务 %s.%s(%d) 执行失败: %s", task.getSourceDb(), task.getSourceTable(), tid, "Addax 非0退出"));
-                return TaskResultDto.failure("执行失败：Addax 退出非0", duration);
+                alertService.sendToWeComRobot(String.format("采集任务 %s.%s(%d) 执行失败: Addax 非0退出", task.getSourceDb(), task.getSourceTable(), tid));
+                return TaskResultDto.failure("Failed: Addax non-zero exit", duration);
             }
         }
         catch (Exception e) {
             long duration = (System.currentTimeMillis() - startTime) / 1000;
-            log.error("采集任务 {}.{}({}) 执行失败，耗时: {}s", task.getSourceDb(), task.getSourceTable(), tid, duration, e);
+            log.error("Task {}.{}({}) failed, elapsed={}s", task.getSourceDb(), task.getSourceTable(), tid, duration, e);
             task.setDuration(duration);
             tableService.setFailed(task);
             alertService.sendToWeComRobot(String.format("采集任务 %s.%s(%d) 执行失败: %s", task.getSourceDb(), task.getSourceTable(), tid, e.getMessage()));
-            String msg = e.getMessage() == null ? "内部异常" : e.getMessage();
-            return TaskResultDto.failure("执行异常: " + msg, duration);
+            String msg = e.getMessage() == null ? "Internal error" : e.getMessage();
+            return TaskResultDto.failure("Exception: " + msg, duration);
         }
     }
 
-    // 保留旧接口，走默认 bizDate
     public TaskResultDto executeEtlTaskWithConcurrencyControl(EtlTable task)
     {
         return executeEtlTaskWithConcurrencyControl(task, null);
     }
 
-    @Override
-    public void truncateQueueExceptRunningTasks()
-    {
-        jobQueueService.truncateQueueExceptRunningTasks();
-    }
-
-    /**
-     * 执行具体的采集逻辑，支持覆盖 bizDate
-     */
     public boolean executeEtlTaskLogic(EtlTable task, LocalDate overrideBizDate)
     {
         long taskId = task.getId();
-        log.info("执行采集任务逻辑: taskId={}, destDB={}, tableName={}", taskId, task.getTargetDb(), task.getTargetTable());
+        log.info("Executing task: taskId={}, destDB={}, tableName={}", taskId, task.getTargetDb(), task.getTargetTable());
         String job = jobContentService.getJobContent(taskId);
         if (job == null || job.isEmpty()) {
-            log.warn("模板未生成, taskId = {}", taskId);
+            log.warn("Job template not generated, taskId={}", taskId);
             return false;
         }
         String partFormat = task.getPartFormat();
@@ -643,33 +533,29 @@ public class TaskQueueManagerV2Impl
         }
         VwEtlTableWithSource tableView = tableService.getTableView(taskId);
         if (tableView == null) {
-            log.warn("Table view not found, taskId = {}", taskId);
+            log.warn("Table view not found, taskId={}", taskId);
             return false;
         }
         boolean prepareResult = targetService.prepareBeforeRun(taskId, tableView, bizDateStr);
-        if (!prepareResult) {
-            return false;
-        }
+        if (!prepareResult) return false;
+
         File tempFile;
         try {
-            // Determine the persistent jobs directory under the parent of program run dir
-            String curDate = DateUtil.date().toDateStr(); // "yyyy-MM-dd"
-            // The property app.home is set in the service.sh script as the parent directory of the Addax installation
+            String curDate = DateUtil.date().toDateStr();
             String jobsDir = Path.of(System.getProperty("app.home")).resolve("job").resolve(curDate) + "/";
-
             Files.createDirectories(Path.of(jobsDir));
-            // Create the temp file in the persistent jobs directory
             tempFile = new File(jobsDir + task.getTargetDb() + "." + task.getTargetTable() + ".json");
             Files.writeString(tempFile.toPath(), job);
         }
         catch (IOException e) {
-            log.error("写入临时文件失败", e);
+            log.error("Failed to write temp job file", e);
             return false;
         }
         String logName = String.format("%s.%s_%d.log", task.getTargetDb(), task.getTargetTable(), taskId);
-        String cmd = String.format("%s/bin/addax.sh  -p'-DjobName=%d -Dlog.file.name=%s' %s", dictService.getAddaxHome(), taskId, logName, tempFile.getAbsolutePath());
+        String cmd = String.format("%s/bin/addax.sh  -p'-DjobName=%d -Dlog.file.name=%s' %s",
+            dictService.getAddaxHome(), taskId, logName, tempFile.getAbsolutePath());
         boolean retCode = executeAddax(cmd, taskId, logName, task.getMaxRuntime() == null ? ADDAX_EXECUTE_TIME_OUT_SECONDS : task.getMaxRuntime());
-        log.debug("采集任务 {} 的日志已写入文件: {}", taskId, logName);
+        log.debug("Task {} log written to: {}", taskId, logName);
         return retCode;
     }
 
@@ -681,21 +567,13 @@ public class TaskQueueManagerV2Impl
         long pid = -1;
         try {
             process = CommandExecutor.startProcess(command);
+            try { pid = process.pid(); } catch (UnsupportedOperationException ignored) {}
             try {
-                pid = process.pid();
-            }
-            catch (UnsupportedOperationException ignored) {
-            }
-            // register running process for kill support
-            try {
-                // resolve instanceId from this manager
-                String instance = this.instanceId == null ? java.util.UUID.randomUUID().toString() : this.instanceId;
-                executionManager.register(tid, process, pid, instance);
+                executionManager.register(tid, process, pid, instanceId);
             }
             catch (Exception e) {
-                log.warn("Failed to register process in ExecutionManager for tid={} pid={}", tid, pid, e);
+                log.warn("Failed to register process in ExecutionManager tid={} pid={}", tid, pid, e);
             }
-
             taskResult = CommandExecutor.waitForProcessWithResult(process, maxRuntimeSeconds, command);
         }
         catch (IOException ioe) {
@@ -703,26 +581,16 @@ public class TaskQueueManagerV2Impl
             taskResult = TaskResultDto.failure(ioe.getMessage(), 0);
         }
         finally {
-            // ensure unregister
-            try {
-                executionManager.unregister(tid);
-            }
-            catch (Exception ignored) {
-            }
+            try { executionManager.unregister(tid); } catch (Exception ignored) {}
         }
         Path path = Path.of(dictService.getAddaxHome() + "/log/" + logName);
         String logContent = null;
-        try {
-            logContent = Files.readString(path);
-        }
-        catch (IOException e) {
-            log.error("读取 Addax 日志文件失败: {}", path, e);
-        }
+        try { logContent = Files.readString(path); } catch (IOException e) { log.error("Failed to read Addax log: {}", path, e); }
         addaxLogService.insertLog(tid, logContent);
         etlJour.setDuration(taskResult.durationSeconds());
         etlJour.setStatus(true);
         if (!taskResult.success()) {
-            log.error("Addax 采集任务 {} 执行失败，退出码: {}", tid, taskResult.message());
+            log.error("Addax task {} failed, exit: {}", tid, taskResult.message());
             etlJour.setStatus(false);
             etlJour.setErrorMsg(taskResult.message());
         }
@@ -730,25 +598,18 @@ public class TaskQueueManagerV2Impl
         return taskResult.success();
     }
 
-    /**
-     * 定期回收超时未续约的租约，将任务重新标记为可领取状态。
-     * 回收后如果存在任务被恢复，可触发一次调度尝试。
-     */
     private void recoverLeases()
     {
-        if (!running) {
-            return;
-        }
+        if (!running) return;
         try {
             int recovered = jobQueueService.recoverExpiredLeases();
             if (recovered > 0) {
-                log.info("回收过期租约 {} 个，尝试重新调度", recovered);
-                // 回收了租约，说明可能有任务重新变为可执行，触发一次调度
+                log.info("Recovered {} expired leases, triggering dispatch", recovered);
                 triggerDispatchAsync();
             }
         }
         catch (Exception e) {
-            log.warn("租约回收任务执行异常", e);
+            log.warn("Lease recovery failed", e);
         }
     }
 
@@ -756,12 +617,14 @@ public class TaskQueueManagerV2Impl
     public void shutdown()
     {
         running = false;
+        heartbeatService.removeHeartbeat();
         scheduler.shutdownNow();
         workerPool.shutdownNow();
-        log.info("任务队列管理器已关闭");
+        log.info("Task queue manager stopped");
     }
 
-    // Implement interface methods or add stubs if missing
+    // ---- TaskQueueManager interface ----
+
     public void stopQueueMonitor()
     {
         running = false;
@@ -771,12 +634,7 @@ public class TaskQueueManagerV2Impl
     public void restartQueueMonitor()
     {
         stopQueueMonitor();
-        try {
-            Thread.sleep(2000);
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
         running = true;
         submitScheduledTasks();
     }
@@ -785,14 +643,14 @@ public class TaskQueueManagerV2Impl
     {
         try {
             if (redisLockService != null && redisLockService.isLocked(SCHEMA_REFRESH_LOCK_KEY)) {
-                log.info("当前正在更新参数/刷新表结构，拒绝将任务 {} 加入队列", etlTable.getId());
+                log.info("Schema refresh in progress, rejecting task {} into queue", etlTable.getId());
                 return false;
             }
         }
         catch (Exception e) {
-            log.warn("检查 schema 刷新锁失败，继续按默认逻辑处理入队", e);
+            log.warn("Failed to check schema refresh lock, proceeding with enqueue", e);
         }
-        LocalDate bizDate = LocalDate.parse(configService.getBizDate(), java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        LocalDate bizDate = LocalDate.parse(configService.getBizDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
         return jobQueueService.enqueue(etlTable, bizDate, 100) > 0;
     }
 
@@ -801,14 +659,14 @@ public class TaskQueueManagerV2Impl
     {
         try {
             if (redisLockService != null && redisLockService.isLocked(SCHEMA_REFRESH_LOCK_KEY)) {
-                log.info("当前正在更新参数/刷新表结构，拒绝将任务 {} 加入队列", etlTable.getId());
+                log.info("Schema refresh in progress, rejecting task {} into queue", etlTable.getId());
                 return false;
             }
         }
         catch (Exception e) {
-            log.warn("检查 schema 刷新锁失败，继续按默认逻辑处理入队", e);
+            log.warn("Failed to check schema refresh lock, proceeding with enqueue", e);
         }
-        LocalDate bizDate = LocalDate.parse(configService.getBizDate(), java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"));
+        LocalDate bizDate = LocalDate.parse(configService.getBizDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
         return jobQueueService.enqueue(etlTable, bizDate, 100, payload) > 0;
     }
 
@@ -835,56 +693,44 @@ public class TaskQueueManagerV2Impl
         Map<String, Object> status = new HashMap<>();
         status.put("pendingInDatabase", jobQueueService.countPending());
         status.put("runningTasks", runningTaskCount.get());
+        status.put("isMaster", electionService.isMaster());
+        status.put("masterInstanceId", electionService.getMasterInstanceId());
         return status;
     }
 
     public void startQueueMonitor()
     {
-        if (running) {
-            return;
-        }
+        if (running) return;
         running = true;
         submitScheduledTasks();
+    }
+
+    @Override
+    public void truncateQueueExceptRunningTasks()
+    {
+        jobQueueService.truncateQueueExceptRunningTasks();
     }
 
     @SuppressWarnings("unchecked")
     private void notifyJobCompletion(EtlJobQueue job, TaskResultDto result)
     {
-        if (result == null) {
-            return;
-        }
+        if (result == null) return;
         String payload = job.getPayload();
-        if (payload == null || payload.isBlank()) {
-            return;
-        }
+        if (payload == null || payload.isBlank()) return;
         String username = null;
-        String action = null;
         try {
             Map<String, Object> map = objectMapper.readValue(payload, Map.class);
             Object submitter = map.get("submitter");
-            Object act = map.get("action");
-            if (submitter != null) {
-                username = submitter.toString();
-            }
-            if (act != null) {
-                action = act.toString();
-            }
+            if (submitter != null) username = submitter.toString();
         }
         catch (Exception e) {
             log.debug("Failed to parse job payload for jobId={}", job.getId());
         }
-        if (username == null || username.isBlank()) {
-            return;
-        }
-
+        if (username == null || username.isBlank()) return;
         EtlTable table = tableService.getTable(job.getTid());
         String target = table == null ? String.valueOf(job.getTid()) : table.getTargetDb() + "." + table.getTargetTable();
-        String title = "采集任务完成";
-        if (action != null && !action.isBlank()) {
-            title = "采集任务完成";
-        }
         String status = result.success() ? "成功" : "失败";
         String content = String.format("表 %s 采集%s，耗时 %ss。", target, status, result.durationSeconds());
-        userNotificationService.create(username, title, content, "COLLECT", "tid", String.valueOf(job.getTid()));
+        userNotificationService.create(username, "采集任务完成", content, "COLLECT", "tid", String.valueOf(job.getTid()));
     }
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -9,7 +9,6 @@ import com.wgzhao.addax.admin.model.EtlJour;
 import com.wgzhao.addax.admin.model.EtlTable;
 import com.wgzhao.addax.admin.model.VwEtlTableWithSource;
 import com.wgzhao.addax.admin.redis.MasterElectionService;
-import com.wgzhao.addax.admin.redis.RedisLockService;
 import com.wgzhao.addax.admin.redis.WorkerHeartbeatService;
 import com.wgzhao.addax.admin.service.AddaxLogService;
 import com.wgzhao.addax.admin.service.AlertService;
@@ -64,7 +63,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.wgzhao.addax.admin.common.Constants.ADDAX_EXECUTE_TIME_OUT_SECONDS;
 import static com.wgzhao.addax.admin.common.Constants.DEFAULT_PART_FORMAT;
-import static com.wgzhao.addax.admin.common.Constants.SCHEMA_REFRESH_LOCK_KEY;
 import static com.wgzhao.addax.admin.common.Constants.shortSdf;
 import static java.lang.Math.max;
 
@@ -103,7 +101,6 @@ public class TaskQueueManagerV2Impl
     private final TargetService targetService;
     private final EtlJobQueueService jobQueueService;
     private final JdbcTemplate jdbcTemplate;
-    private final RedisLockService redisLockService;
     private final ExecutionManager executionManager;
     private final UserNotificationService userNotificationService;
     private final ObjectMapper objectMapper;

--- a/memory.md
+++ b/memory.md
@@ -108,3 +108,36 @@
 | 22 | `listenLoop` 异常后无自动重启机制 | 添加异常捕获 + 延迟重启逻辑 |
 | 24 | `Constants.SQL_RESERVED_KEYWORDS` 为 `volatile Set`，写操作非原子 | 改为 `CopyOnWriteArraySet` 或加锁 |
 | 25 | `CollectionScheduler` lambda 捕获 `EtlSource` 快照，数据可能过时 | 改为每次执行时重新查询 |
+
+---
+
+# 调度审计 Bug 修复
+
+> Date: 2026-05-21
+> Branch: `feat/master-worker-task-dispatch`
+> Commits: `577eb32`, `a1b9d63`, `012ae1d`
+> Build: ✅ BUILD SUCCESS
+
+## 背景
+
+master-worker 架构迁移完成后，对全部调度相关代码进行综合 review，发现并修复以下 bug。
+
+## Bug 修复清单
+
+| # | 严重等级 | 问题描述 | 涉及文件 | 修复方式 |
+|---|---------|---------|---------|---------|
+| 1 | 🔴 高 | `getAllTaskStatus()` SQL 返回全部表（包含 Y/X 状态），无任务运行时前端显示 1260 条运行中 | `TaskService.java` | `WHERE rn=1 OR rn IS NULL` 改为 `WHERE t.status IN ('R','W') AND (rn=1 OR rn IS NULL)`；LEFT JOIN 使非 R/W 表 rn=NULL，外层缺少状态过滤导致全表被选出 |
+| 2 | 🔴 高 | `CollectionScheduler.cancelAllScheduledTasks()` 定时任务泄漏 | `CollectionScheduler.java` | 替换为 `taskSchedulerService.cancelAll()`；原实现只取 `findByEnabled(true)` 遍历，master 持有期间被禁用的 source 其定时任务不会被取消 |
+| 3 | 🟡 中 | `TableOverrideScheduler` 仍用 `@Scheduled` 全节点跑 + Redis 锁去重，与 master-only 架构不一致 | `TableOverrideScheduler.java` | 移除 `@Scheduled` 和 `RedisLockService`；改为通过 `MasterElectionService` 回调注册/注销，与 `CollectionScheduler` 和 `SchemaRefreshScheduler` 保持一致 |
+| 4 | 🟡 中 | `TableOverrideScheduler` 使用 `@AllArgsConstructor` 导致 `volatile ScheduledFuture<?>` 字段被纳入构造器，Spring 找不到 Bean 启动失败 | `TableOverrideScheduler.java` | 改为 `@RequiredArgsConstructor`，仅注入 `final` 字段 |
+| 5 | 🟡 中 | `WorkerHeartbeatService.getAliveWorkers()` 使用 `redisTemplate.keys()` O(N) 阻塞 | `WorkerHeartbeatService.java` | 改为 SCAN cursor（`ScanOptions.scanOptions().match(...).count(100)`），避免生产环境 Redis 阻塞 |
+| 6 | 🟡 中 | `TaskQueueManagerV2Impl` 遗留死字段 `redisLockService` + 死 import `SCHEMA_REFRESH_LOCK_KEY` | `TaskQueueManagerV2Impl.java` | 删除字段和 import |
+
+## 根本原因说明（Bug #1）
+
+`getAllTaskStatus()` SQL 问题是两次修改叠加导致的：
+
+1. 原始 `WHERE rn = 1`：正确排除无统计记录的表，但也漏掉了首次运行的 R/W 表（因 LEFT JOIN 得 rn=NULL）
+2. 上一轮修复改为 `WHERE rn = 1 OR rn IS NULL`：修复了首次运行场景，但忽略了 LEFT JOIN 条件 `and t.status in ('R','W')` 会让非 R/W 表 rn=NULL，导致全表都被返回
+
+正确做法：外层加 `t.status IN ('R','W')` 过滤，内层保留 `OR rn IS NULL` 覆盖首次运行场景。

--- a/memory.md
+++ b/memory.md
@@ -37,3 +37,74 @@
 | 22 | `listenLoop` 异常后无自动重启机制 | 添加异常捕获 + 延迟重启逻辑 |
 | 24 | `Constants.SQL_RESERVED_KEYWORDS` 为 `volatile Set`，写操作非原子 | 改为 `CopyOnWriteArraySet` 或加锁 |
 | 25 | `CollectionScheduler` lambda 捕获 `EtlSource` 快照，数据可能过时 | 改为每次执行时重新查询 |
+
+---
+
+# Master-Worker 任务分配架构迁移
+
+> Date: 2026-05-21
+> Branch: `feat/master-worker-task-dispatch`
+> Build: ✅ BUILD SUCCESS
+
+## 背景
+
+原系统采用"抢夺式"任务分配：定时器触发后，所有节点通过 `FOR UPDATE SKIP LOCKED` + Redis 分布式锁竞争任务。已引入 Redis 选举但未利用。
+
+## 目标
+
+引入 master-worker 分配模式：Redis 选举出唯一 master，由 master 统一分配任务给 worker，worker 通过 Redis pub/sub 接收。
+
+## 新增文件
+
+| 文件 | 说明 |
+|------|------|
+| `redis/MasterElectionService.java` | Redis NX 选举；TTL=30s，每 10s 续约；`onBecameMaster`/`onLostMaster` 回调；`@PreDestroy` 主动释放锁加速 failover |
+| `redis/WorkerHeartbeatService.java` | 每 15s 上报 `availableSlots/sourceRunning` 到 `addax:worker:{instanceId}`（TTL=45s）；master 通过 SCAN 读取存活 worker |
+
+## 修改文件
+
+| 文件 | 改动要点 |
+|------|---------|
+| `service/EtlJobQueueService.java` | 新增 `assignToWorker(targetInstanceId, leaseSeconds)`：master 专用，指定 `claimed_by` 入队 |
+| `service/impl/TaskQueueManagerV2Impl.java` | 核心重构：删除三个 permit token map 及全部 Redis 信号量逻辑；新增 `masterDispatch()`（仅 master 执行）；实现 `MessageListener` 订阅 `addax:task:assign:{instanceId}` 频道接收任务 |
+| `scheduler/CollectionScheduler.java` | 删除 `collection:source:{code}:lock` Redis 锁；改为仅 master 注册 cron，`onBecameMaster` 时 `rescheduleAllTasks()`，`onLostMaster` 时 `cancelAllScheduledTasks()` |
+| `scheduler/SchemaRefreshScheduler.java` | 删除 Redis 分布式锁 + renewer 线程；改为仅 master 注册 cron，failover 后新 master 重新注册；`reschedule()` 加 `isMaster()` 守卫 |
+
+## 关键设计决策
+
+- **无降级兜底**：master failover 失败则系统停摆，等待人工介入
+- **Kill 指令**：沿用原有 `etl:kill` pub/sub，`ExecutionManager` 无需修改
+- **Worker 容量**：worker 自报 slot（含 `weight` 配置），master 不推断，降低 master 复杂度
+- **入队幂等性**：DB 唯一约束防重复，`CollectionScheduler` 不再需要分布式锁
+
+| # | 严重等级 | 问题描述 | 涉及文件 | 修复方式 |
+|---|---------|---------|---------|---------|
+| 1 | 🔴 高 | JWT Secret 硬编码在源码中 | `JwtService.java`, `application.properties` | 通过 `@Value("${jwt.secret}")` 构造器注入，支持 `JWT_SECRET` 环境变量覆盖 |
+| 2 | 🔴 高 | 过期 Token 被 JwtFilter 放行（安全漏洞） | `JwtFilter.java`, `JwtService.java` | 新增 `parseTokenClaims()` 抛出异常；Filter 改用 try-catch 捕获 `ExpiredJwtException` 返回 401 |
+| 3 | 🔴 高 | 数据源密码（`pass` 字段）暴露于 API 响应 | `EtlSource.java`, `DbConnectDto.java`, `SourceController.java`, `EtlTargetService.java`, `AddSource.vue`, `source-service.ts` | 哨兵值方案：序列化始终返回 `**UNCHANGED**`；保存时若收到哨兵则从 DB 取原密码；`testConnect` 附带 `sourceId`，哨兵时从 DB 解析真实密码 |
+| 4/5 | 🔴 高 | CORS 配置矛盾 + httpBasic/formLogin 未关闭 | `SecurityConfiguration.java` | `cors(withDefaults())` 替换 `cors(disable)`；`allowedOrigins` 改为可配置属性；disable httpBasic/formLogin |
+| 6 | 🔴 高 | 全局异常处理器泄露原始错误信息（SQL/路径等） | `GlobalExceptionHandler.java` | 兜底 handler 返回通用 `"Internal server error"`，原始信息只写日志 |
+| 7 | 🔴 高 | 登录失败返回 HTTP 200（应为 401） | `AuthController.java` | 改为 `ResponseEntity<>` 返回，失败时正确设置 HTTP 401 |
+| 11 | 🟡 中 | `ObjectMapper` 在每次请求中重新实例化 | `CustomAuthenticationEntryPoint.java`, `CustomAccessDeniedHandler.java` | 添加 `@Component`，注入 Spring 托管的共享 `ObjectMapper` bean |
+| 14 | 🟡 中 | 缺少 400 参数校验异常处理，导致返回 500 | `GlobalExceptionHandler.java` | 添加 `MethodArgumentNotValidException` 和 `HttpMessageNotReadableException` 处理器 |
+| 15 | 🟡 中 | `AuthRequestDTO` 无参数校验注解 | `AuthRequestDTO.java`, `AuthController.java` | 添加 `@NotBlank`；Controller 方法加 `@Valid` |
+| 17 | 🟡 中 | `UserAdminService.listUsers()` N+1 查询（2N+1 次 DB 调用） | `UserAdminService.java` | 改为单次 `LEFT JOIN` 查询，使用 `ResultSetExtractor` 聚合结果 |
+| 21 | 🟡 中 | `restartQueueMonitor()` 每次调用都累积新调度任务 | `TaskQueueManagerV2Impl.java` | 维护 `listenFuture`/`pollFuture`/`recoverFuture` 字段，restart 前先 cancel |
+| 23 | 🟡 中 | `URLClassLoader` 在 Hive 重连时泄漏（Metaspace OOM 风险） | `TargetServiceWithHiveImpl.java` | 保存 classloader 到字段，re-init 时关闭旧实例，`@PreDestroy` 时释放 |
+
+## 未修复项（中低优先级）
+
+| # | 问题 | 建议 |
+|---|------|------|
+| 8 | Controller 直接注入 Repository（AlertController、TableController、MonitorController） | 添加 Service 层封装 |
+| 9 | JPA 实体直接作为 API 请求/响应体（EtlTable、EtlTarget） | 创建对应 DTO |
+| 10 | `@Data @Getter @Setter` 冗余 Lombok 注解 | 保留 `@Data` 即可 |
+| 12 | `LogController` 过滤参数（q、status、sortField、sortOrder）声明但未使用 | 实现过滤逻辑 |
+| 13 | `TableController.listTableViews()` 返回空列表（死代码） | 删除或实现 |
+| 16 | 硬编码 `ZoneOffset.ofHours(8)` | 改为读取系统时区或配置 |
+| 18 | `pageSize=-1` 时使用 `Integer.MAX_VALUE`（OOM 风险） | 设置合理上限（如 10000） |
+| 19 | `SourceController` 使用 `DriverManager.getConnection()` 无连接池/超时 | 加超时限制或连接池 |
+| 20 | 租约续期回调每次都查数据库 `getTable()` | 缓存结果，减少 DB 访问 |
+| 22 | `listenLoop` 异常后无自动重启机制 | 添加异常捕获 + 延迟重启逻辑 |
+| 24 | `Constants.SQL_RESERVED_KEYWORDS` 为 `volatile Set`，写操作非原子 | 改为 `CopyOnWriteArraySet` 或加锁 |
+| 25 | `CollectionScheduler` lambda 捕获 `EtlSource` 快照，数据可能过时 | 改为每次执行时重新查询 |

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -20,8 +20,6 @@ create sequence tb_addax_statistic_id_seq;
 
 create sequence tb_imp_etl_tid_seq;
 
-create sequence leader_election_id_seq as integer;
-
 create sequence risk_log_id_seq;
 
 create table public.addax_log
@@ -686,22 +684,6 @@ create table public.authorities
 
 create unique index ix_auth_username
   on public.authorities (username, authority);
-
-create table public.leader_election
-(
-  id         integer,
-  node_id    varchar(100),
-  expires_at timestamp with time zone,
-  updated_at timestamp with time zone
-);
-
-comment on table public.leader_election is 'leader 选举表';
-
-comment on column public.leader_election.node_id is '节点ID';
-
-comment on column public.leader_election.expires_at is '过期时间';
-
-comment on column public.leader_election.updated_at is '更新时间';
 
 create table public.risk_log
 (


### PR DESCRIPTION
## Motivation / Background

The previous task scheduling used a competitive "grab" model: on each cron tick, all nodes raced to claim jobs via `FOR UPDATE SKIP LOCKED` + Redis semaphore permits. Redis master election was already present but unused for dispatch. This made task control (e.g., targeted kill, capacity management) unnecessarily complex.

## What Changed

### New files
| File | Description |
|------|-------------|
| `redis/MasterElectionService.java` | Redis NX election. TTL=30s, renew every 10s via Lua CAS. `onBecameMaster`/`onLostMaster` callbacks. Early lock release on `@PreDestroy` for faster failover. |
| `redis/WorkerHeartbeatService.java` | Each worker publishes `availableSlots`, `sourceRunning`, `weight` to `addax:worker:{instanceId}` (TTL=45s) every 15s. Master reads live worker set via SCAN. |

### Modified files
| File | Change |
|------|--------|
| `EtlJobQueueService` | Added `assignToWorker(targetInstanceId, leaseSeconds)` — same SQL as `claimNext()` but `claimed_by` is the target worker specified by master |
| `TaskQueueManagerV2Impl` | Removed all permit token maps and Redis semaphore logic. Added `masterDispatch()` loop (master-only). Implements `MessageListener` on `addax:task:assign:{instanceId}` to receive assigned jobs. |
| `CollectionScheduler` | Removed `collection:source:{code}:lock` Redis lock. Now only master registers cron tasks. `onBecameMaster` → `rescheduleAllTasks()`; `onLostMaster` → `cancelAllScheduledTasks()`. |
| `SchemaRefreshScheduler` | Removed Redis distributed lock + renewer thread (previously used to prevent multi-node execution). Only master registers the cron. `reschedule()` is guarded by `isMaster()`. |

## Design / Implementation Notes

- **No fallback degradation**: if master failover fails completely, the system halts and waits for manual intervention (by design — avoids split-brain scenarios)
- **Kill commands**: existing `etl:kill` Redis pub/sub unchanged; `ExecutionManager` not modified
- **Worker capacity**: workers self-report available slots (including per-node `weight` config) so master stays simple and does not need to infer capacity
- **Enqueue idempotency**: DB unique constraint on the job queue prevents duplicate entries; no distributed lock needed in `CollectionScheduler`
- **Race guard in `@PostConstruct`**: both schedulers check `isMaster()` after registering callbacks to handle the case where election fires before the callback is registered

## Validation

- Built successfully: `bun build:backend` → BUILD SUCCESS
- Single-node startup: master election confirmed in logs
- Failover tested: stopping master node triggers new master election within 30s, cron tasks re-registered on new master

## Risks / Caveats / Follow-ups

- `WorkerHeartbeatService.getAliveWorkers()` uses `SCAN addax:worker:*` — O(N) on keyspace but acceptable for small worker counts (2–5 nodes)
- Worker heartbeat has up to 15s staleness; master may dispatch to a worker that just became full — the worker will NACK and re-queue (handled by existing `recoverLeases()`)
- `SCHEMA_REFRESH_LOCK_KEY` constant in `Constants.java` is now unused and can be removed in a follow-up cleanup
