### PR TITLE
feat: replace greedy dispatch with SWRR + dead-worker recovery

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/controller/ClusterController.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/controller/ClusterController.java
@@ -1,0 +1,70 @@
+package com.wgzhao.addax.admin.controller;
+
+import com.wgzhao.addax.admin.redis.MasterElectionService;
+import com.wgzhao.addax.admin.redis.WorkerHeartbeatService;
+import com.wgzhao.addax.admin.redis.WorkerHeartbeatService.WorkerInfo;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cluster status API — exposes alive worker nodes and master identity.
+ */
+@RestController
+@RequestMapping("/cluster")
+@AllArgsConstructor
+public class ClusterController
+{
+    private final WorkerHeartbeatService heartbeatService;
+    private final MasterElectionService electionService;
+
+    /**
+     * Returns all alive worker nodes with their current state.
+     * The master node is identified via masterInstanceId in the response.
+     */
+    @GetMapping("/nodes")
+    public ResponseEntity<Map<String, Object>> nodes()
+    {
+        List<WorkerInfo> workers = heartbeatService.getAliveWorkers();
+        String masterInstanceId = electionService.getMasterInstanceId();
+
+        List<Map<String, Object>> nodes = workers.stream()
+            .map(w -> {
+                boolean isMaster = w.instanceId().equals(masterInstanceId);
+                return Map.<String, Object>of(
+                    "instanceId", w.instanceId(),
+                    "host", w.host(),
+                    "role", isMaster ? "MASTER/WORKER" : "WORKER",
+                    "running", w.running(),
+                    "availableSlots", w.availableSlots(),
+                    "concurrentLimit", w.concurrentLimit(),
+                    "weight", w.weight(),
+                    "sourceRunning", w.sourceRunning(),
+                    "lastSeen", w.lastSeen() != null ? w.lastSeen().toString() : null,
+                    "online", true
+                );
+            })
+            .sorted((a, b) -> {
+                // master first
+                boolean aMaster = "MASTER".equals(a.get("role"));
+                boolean bMaster = "MASTER".equals(b.get("role"));
+                if (aMaster && !bMaster) return -1;
+                if (!aMaster && bMaster) return 1;
+                return a.get("instanceId").toString().compareTo(b.get("instanceId").toString());
+            })
+            .toList();
+
+        return ResponseEntity.ok(Map.of(
+            "nodes", nodes,
+            "masterInstanceId", masterInstanceId != null ? masterInstanceId : "",
+            "totalNodes", nodes.size(),
+            "timestamp", Instant.now().toString()
+        ));
+    }
+}

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java
@@ -16,6 +16,8 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -213,5 +215,42 @@ public class EtlJobQueueService
     public void truncateQueueExceptRunningTasks()
     {
         jobRepo.deleteByStatusNot("running");
+    }
+
+    /**
+     * Release all running tasks claimed by a specific worker instance.
+     * Called when master detects a worker has disappeared between dispatch cycles.
+     */
+    @Transactional
+    public int releaseClaimedByInstance(String instanceId)
+    {
+        String sql = """
+                UPDATE public.etl_job_queue
+                SET status='pending', available_at=now(), lease_until=NULL, claimed_by=NULL, claimed_at=NULL
+                WHERE status='running' AND claimed_by=?
+            """;
+        return jdbcTemplate.update(sql, instanceId);
+    }
+
+    /**
+     * Release running tasks whose claimed_by is not in the provided alive worker set.
+     * Called once on master startup (after waiting for workers to re-register) to recover
+     * tasks that were claimed by nodes that never came back.
+     * If aliveInstanceIds is empty, ALL running tasks are released (entire cluster was restarted).
+     */
+    @Transactional
+    public int releaseOrphanedJobs(Set<String> aliveInstanceIds)
+    {
+        if (aliveInstanceIds.isEmpty()) {
+            String sql = """
+                    UPDATE public.etl_job_queue
+                    SET status='pending', available_at=now(), lease_until=NULL, claimed_by=NULL, claimed_at=NULL
+                    WHERE status='running'
+                """;
+            return jdbcTemplate.update(sql);
+        }
+        String placeholders = aliveInstanceIds.stream().map(id -> "?").collect(Collectors.joining(", "));
+        String sql = "UPDATE public.etl_job_queue SET status='pending', available_at=now(), lease_until=NULL, claimed_by=NULL, claimed_at=NULL WHERE status='running' AND claimed_by NOT IN (" + placeholders + ")";
+        return jdbcTemplate.update(sql, aliveInstanceIds.toArray());
     }
 }

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -51,6 +51,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -60,6 +62,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static com.wgzhao.addax.admin.common.Constants.ADDAX_EXECUTE_TIME_OUT_SECONDS;
 import static com.wgzhao.addax.admin.common.Constants.DEFAULT_PART_FORMAT;
@@ -133,10 +136,16 @@ public class TaskQueueManagerV2Impl
     private String instanceId;
     private double concurrencyWeight = 1.0;
 
+    // SWRR state: master-only, tracks accumulated weight per worker between dispatch cycles
+    private final ConcurrentHashMap<String, Double> swrrCurrentWeight = new ConcurrentHashMap<>();
+    // Tracks alive workers seen in the previous dispatch cycle for dead-worker detection
+    private final Set<String> knownWorkerIds = new HashSet<>();
+
     private volatile Future<?> listenFuture;
     private volatile ScheduledFuture<?> pollFuture;
     private volatile ScheduledFuture<?> recoverFuture;
     private volatile ScheduledFuture<?> heartbeatFuture;
+    private volatile ScheduledFuture<?> orphanRecoverFuture;
 
     @PostConstruct
     public void init()
@@ -192,13 +201,47 @@ public class TaskQueueManagerV2Impl
     private void onBecameMaster()
     {
         log.info("Became master — starting dispatch loop");
-        // pollAndDispatch will now call masterDispatch() because isMaster() is true
+        knownWorkerIds.clear();
+        // Wait 2× heartbeat interval for workers to re-register, then release orphaned tasks
+        if (orphanRecoverFuture != null) orphanRecoverFuture.cancel(false);
+        orphanRecoverFuture = scheduler.schedule(this::recoverOrphanedJobs,
+            2L * HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
     private void onLostMaster()
     {
         log.info("Lost master role — pausing dispatch (workers continue executing current tasks)");
-        // pollAndDispatch will skip masterDispatch() because isMaster() is false
+        swrrCurrentWeight.clear();
+        knownWorkerIds.clear();
+        if (orphanRecoverFuture != null) {
+            orphanRecoverFuture.cancel(false);
+            orphanRecoverFuture = null;
+        }
+    }
+
+    /**
+     * One-shot task scheduled 2× HEARTBEAT_INTERVAL_SECONDS after becoming master.
+     * Releases tasks claimed by instances that did not re-register as alive workers.
+     */
+    private void recoverOrphanedJobs()
+    {
+        if (!electionService.isMaster()) return;
+        try {
+            Set<String> aliveIds = heartbeatService.getAliveWorkers().stream()
+                .map(WorkerHeartbeatService.WorkerInfo::instanceId)
+                .collect(Collectors.toSet());
+            int recovered = jobQueueService.releaseOrphanedJobs(aliveIds);
+            if (recovered > 0) {
+                log.info("Orphan recovery: released {} tasks claimed by disappeared workers (alive={})", recovered, aliveIds);
+                triggerDispatchAsync();
+            }
+            else {
+                log.debug("Orphan recovery: no orphaned tasks found (alive={})", aliveIds);
+            }
+        }
+        catch (Exception e) {
+            log.error("Orphan recovery failed", e);
+        }
     }
 
     // ---- Worker: receive task assignment via Redis pub/sub ----
@@ -313,11 +356,9 @@ public class TaskQueueManagerV2Impl
     /**
      * Master-only: read alive workers, assign pending jobs from DB queue via Redis pub/sub.
      *
-     * For each worker with available slots, we atomically claim a job (assigned to that worker)
-     * and publish the job JSON to the worker's personal channel. The worker picks it up and executes.
-     *
-     * Source-level concurrency: checked against worker.sourceRunning from the heartbeat.
-     * There is up to HEARTBEAT_INTERVAL_SECONDS staleness — acceptable for this use case.
+     * Uses Smooth Weighted Round Robin (SWRR) to distribute tasks proportionally to worker weights.
+     * Source-level concurrency is checked against worker.sourceRunning from the heartbeat
+     * (up to HEARTBEAT_INTERVAL_SECONDS staleness — acceptable for this use case).
      */
     private void masterDispatch()
     {
@@ -327,50 +368,131 @@ public class TaskQueueManagerV2Impl
             return;
         }
 
-        for (WorkerHeartbeatService.WorkerInfo worker : workers) {
-            int slots = worker.availableSlots();
-            if (slots <= 0) continue;
-
-            for (int i = 0; i < slots; i++) {
-                // Assign next pending job to this worker
-                Optional<EtlJobQueue> maybe = jobQueueService.assignToWorker(worker.instanceId(), DEFAULT_LEASE_SECONDS);
-                if (maybe.isEmpty()) {
-                    // No more pending jobs
-                    return;
-                }
-                EtlJobQueue job = maybe.get();
-
-                // Check source-level concurrency via worker's heartbeat data
-                EtlTable table = tableService.getTable(job.getTid());
-                if (table != null) {
-                    VwEtlTableWithSource source = tableService.getTableView(table.getId());
-                    if (source != null && source.getMaxConcurrency() != null && source.getMaxConcurrency() > 0) {
-                        int effectiveLimit = Math.max(1, (int) Math.floor(source.getMaxConcurrency() * worker.weight()));
-                        int workerSrcRunning = worker.sourceRunning().getOrDefault(table.getSid(), 0);
-                        if (workerSrcRunning >= effectiveLimit) {
-                            // Source concurrency exceeded for this worker — release and try another worker
-                            log.debug("Source {} concurrency limit reached for worker {}, releasing job {}",
-                                source.getCode(), worker.instanceId(), job.getId());
-                            jobQueueService.releaseClaim(job.getId(), 5);
-                            try { tableService.setWaiting(table); } catch (Exception ignored) {}
-                            break; // move to next worker
+        // Detect workers that disappeared since last dispatch cycle and proactively recover their tasks,
+        // avoiding waiting for DEFAULT_LEASE_SECONDS (7300s) expiry.
+        Set<String> currentWorkerIds = workers.stream()
+            .map(WorkerHeartbeatService.WorkerInfo::instanceId)
+            .collect(Collectors.toSet());
+        if (!knownWorkerIds.isEmpty()) {
+            for (String deadId : new HashSet<>(knownWorkerIds)) {
+                if (!currentWorkerIds.contains(deadId)) {
+                    log.warn("Worker {} disappeared — recovering its claimed tasks immediately", deadId);
+                    try {
+                        int recovered = jobQueueService.releaseClaimedByInstance(deadId);
+                        if (recovered > 0) {
+                            log.info("Released {} tasks from dead worker {}", recovered, deadId);
                         }
                     }
-                }
-
-                // Publish job to worker's channel
-                try {
-                    String assignPayload = objectMapper.writeValueAsString(job);
-                    String channel = TASK_ASSIGN_CHANNEL_PREFIX + worker.instanceId();
-                    stringRedisTemplate.convertAndSend(channel, assignPayload);
-                    log.info("Assigned job {} (tid={}) to worker {}", job.getId(), job.getTid(), worker.instanceId());
-                }
-                catch (Exception e) {
-                    log.error("Failed to publish task assignment for jobId={} to worker={}", job.getId(), worker.instanceId(), e);
-                    // Release the claim so another dispatch cycle can retry
-                    try { jobQueueService.releaseClaim(job.getId(), 5); } catch (Exception ignored) {}
+                    catch (Exception e) {
+                        log.error("Failed to release tasks from dead worker {}", deadId, e);
+                    }
                 }
             }
+        }
+        knownWorkerIds.clear();
+        knownWorkerIds.addAll(currentWorkerIds);
+
+        // Clean up SWRR state for workers that are no longer alive
+        swrrCurrentWeight.keySet().retainAll(currentWorkerIds);
+
+        // Mutable per-cycle slot snapshot to prevent over-dispatching within one cycle
+        // (heartbeat data is stale by up to HEARTBEAT_INTERVAL_SECONDS)
+        List<WorkerSlot> slots = workers.stream()
+            .map(w -> new WorkerSlot(w, w.availableSlots()))
+            .collect(Collectors.toCollection(java.util.ArrayList::new));
+
+        while (true) {
+            WorkerSlot selected = selectWorkerSwrr(slots);
+            if (selected == null) return; // all workers have no available slots
+
+            Optional<EtlJobQueue> maybe = jobQueueService.assignToWorker(selected.worker.instanceId(), DEFAULT_LEASE_SECONDS);
+            if (maybe.isEmpty()) return; // no more pending jobs
+
+            EtlJobQueue job = maybe.get();
+
+            // Check source-level concurrency via worker's heartbeat data
+            EtlTable table = tableService.getTable(job.getTid());
+            if (table != null) {
+                VwEtlTableWithSource source = tableService.getTableView(table.getId());
+                if (source != null && source.getMaxConcurrency() != null && source.getMaxConcurrency() > 0) {
+                    int effectiveLimit = Math.max(1, (int) Math.floor(source.getMaxConcurrency() * selected.worker.weight()));
+                    int workerSrcRunning = selected.worker.sourceRunning().getOrDefault(table.getSid(), 0);
+                    if (workerSrcRunning >= effectiveLimit) {
+                        log.debug("Source {} concurrency limit reached for worker {}, releasing job {}",
+                            source.getCode(), selected.worker.instanceId(), job.getId());
+                        jobQueueService.releaseClaim(job.getId(), 5);
+                        try { tableService.setWaiting(table); } catch (Exception ignored) {}
+                        // Zero out this worker's slot so SWRR won't select it again this cycle;
+                        // a fresh dispatch cycle will re-evaluate once heartbeat is updated
+                        selected.slots = 0;
+                        continue;
+                    }
+                }
+            }
+
+            // Publish job to worker's channel
+            try {
+                String assignPayload = objectMapper.writeValueAsString(job);
+                String channel = TASK_ASSIGN_CHANNEL_PREFIX + selected.worker.instanceId();
+                stringRedisTemplate.convertAndSend(channel, assignPayload);
+                log.info("Assigned job {} (tid={}) to worker {}", job.getId(), job.getTid(), selected.worker.instanceId());
+                selected.slots--; // deduct in-cycle to avoid over-dispatching to same worker
+            }
+            catch (Exception e) {
+                log.error("Failed to publish task assignment for jobId={} to worker={}", job.getId(), selected.worker.instanceId(), e);
+                try { jobQueueService.releaseClaim(job.getId(), 5); } catch (Exception ignored) {}
+            }
+        }
+    }
+
+    /**
+     * Smooth Weighted Round Robin selection.
+     * Each call: all workers gain configuredWeight, then the one with highest currentWeight
+     * and available slots is chosen and loses totalWeight.
+     *
+     * @return selected WorkerSlot, or null if no worker has slots
+     */
+    private WorkerSlot selectWorkerSwrr(List<WorkerSlot> slots)
+    {
+        if (slots.isEmpty()) return null;
+
+        double totalWeight = slots.stream().mapToDouble(s -> s.worker.weight()).sum();
+
+        // Step 1: every worker accumulates its configured weight
+        for (WorkerSlot s : slots) {
+            swrrCurrentWeight.merge(s.worker.instanceId(), s.worker.weight(), Double::sum);
+        }
+
+        // Step 2: select the worker with the highest accumulated weight that has a free slot
+        WorkerSlot selected = null;
+        double maxCw = Double.NEGATIVE_INFINITY;
+        for (WorkerSlot s : slots) {
+            if (s.slots <= 0) continue;
+            double cw = swrrCurrentWeight.getOrDefault(s.worker.instanceId(), 0.0);
+            if (cw > maxCw) {
+                maxCw = cw;
+                selected = s;
+            }
+        }
+
+        if (selected == null) return null;
+
+        // Step 3: deduct total weight from the selected worker
+        swrrCurrentWeight.merge(selected.worker.instanceId(), -totalWeight, Double::sum);
+
+        return selected;
+    }
+
+    /** Per-cycle mutable slot tracker to prevent over-dispatching within a single masterDispatch() call. */
+    private static final class WorkerSlot
+    {
+        final WorkerHeartbeatService.WorkerInfo worker;
+        int slots;
+
+        WorkerSlot(WorkerHeartbeatService.WorkerInfo worker, int slots)
+        {
+            this.worker = worker;
+            this.slots = slots;
         }
     }
 

--- a/frontend/src/layouts/default/Topbar.vue
+++ b/frontend/src/layouts/default/Topbar.vue
@@ -255,6 +255,10 @@ const urls = ref<MenuItem[]>([
   {
     path: '/dict',
     title: '字典维护'
+  },
+  {
+    path: '/cluster',
+    title: '集群状态'
   }
   // {
   //   path: '/param',

--- a/frontend/src/service/cluster-service.ts
+++ b/frontend/src/service/cluster-service.ts
@@ -1,0 +1,31 @@
+import Requests from '@/utils/requests'
+
+export interface WorkerNode {
+  instanceId: string
+  host: string
+  role: 'MASTER/WORKER' | 'WORKER'
+  running: number
+  availableSlots: number
+  concurrentLimit: number
+  weight: number
+  sourceRunning: Record<string, number>
+  lastSeen: string | null
+  online: boolean
+}
+
+export interface ClusterStatus {
+  nodes: WorkerNode[]
+  masterInstanceId: string
+  totalNodes: number
+  timestamp: string
+}
+
+class ClusterService {
+  prefix = '/cluster'
+
+  getNodes(): Promise<ClusterStatus> {
+    return Requests.get(`${this.prefix}/nodes`) as unknown as Promise<ClusterStatus>
+  }
+}
+
+export const clusterService = new ClusterService()

--- a/frontend/src/views/cluster.vue
+++ b/frontend/src/views/cluster.vue
@@ -1,0 +1,224 @@
+<template>
+  <v-container fluid class="pa-6 cluster-page">
+    <!-- header row -->
+    <v-row align="center" class="mb-4">
+      <v-col>
+        <div class="text-h6 font-weight-medium">集群状态</div>
+        <div class="text-caption text-medium-emphasis">节点最近心跳超过 30 秒视为离线</div>
+      </v-col>
+      <v-col cols="auto">
+        <v-chip
+          :color="status.totalNodes > 0 ? 'success' : 'warning'"
+          variant="tonal"
+          size="small"
+          class="mr-2"
+        >
+          在线节点：{{ status.totalNodes }}
+        </v-chip>
+        <v-btn
+          variant="tonal"
+          size="small"
+          :loading="loading"
+          prepend-icon="mdi-refresh"
+          @click="refresh"
+        >刷新</v-btn>
+      </v-col>
+    </v-row>
+
+    <v-alert v-if="error" type="error" variant="tonal" class="mb-4" closable>{{ error }}</v-alert>
+
+    <!-- node cards -->
+    <v-row dense>
+      <v-col
+        v-for="node in status.nodes"
+        :key="node.instanceId"
+        cols="12"
+        sm="6"
+        lg="4"
+      >
+        <v-card
+          :color="node.role.includes('MASTER') ? 'primary' : undefined"
+          :variant="node.role.includes('MASTER') ? 'tonal' : 'outlined'"
+          class="node-card"
+        >
+          <!-- card title row -->
+          <v-card-title class="d-flex align-center gap-2 pb-1">
+            <v-icon :color="node.role.includes('MASTER') ? 'primary' : 'secondary'" size="20">
+              {{ node.role.includes('MASTER') ? 'mdi-crown' : 'mdi-server' }}
+            </v-icon>
+            <span class="text-subtitle-1 font-weight-medium text-truncate" :title="node.instanceId">
+              {{ node.host }}
+            </span>
+            <v-spacer />
+            <v-chip
+              :color="node.role.includes('MASTER') ? 'primary' : 'default'"
+              size="x-small"
+              variant="elevated"
+            >{{ node.role }}</v-chip>
+          </v-card-title>
+
+          <v-card-text class="pt-0">
+            <!-- concurrency bar -->
+            <div class="d-flex justify-space-between text-caption mb-1">
+              <span>并发使用</span>
+              <span>{{ node.running }} / {{ node.concurrentLimit }}</span>
+            </div>
+            <v-progress-linear
+              :model-value="node.concurrentLimit > 0 ? (node.running / node.concurrentLimit) * 100 : 0"
+              :color="slotColor(node)"
+              rounded
+              height="6"
+              class="mb-3"
+            />
+
+            <!-- info items -->
+            <v-list density="compact" class="node-info-list pa-0">
+              <v-list-item class="px-0 py-0">
+                <template #prepend>
+                  <v-icon size="14" class="mr-1 text-medium-emphasis">mdi-identifier</v-icon>
+                </template>
+                <v-list-item-subtitle class="text-caption text-truncate" :title="node.instanceId">
+                  {{ node.instanceId }}
+                </v-list-item-subtitle>
+              </v-list-item>
+
+              <v-list-item class="px-0 py-0">
+                <template #prepend>
+                  <v-icon size="14" class="mr-1 text-medium-emphasis">mdi-weight</v-icon>
+                </template>
+                <v-list-item-subtitle class="text-caption">
+                  权重：{{ node.weight }}
+                </v-list-item-subtitle>
+              </v-list-item>
+
+              <v-list-item class="px-0 py-0">
+                <template #prepend>
+                  <v-icon size="14" class="mr-1 text-medium-emphasis">mdi-slot-machine</v-icon>
+                </template>
+                <v-list-item-subtitle class="text-caption">
+                  可用 Slot：{{ node.availableSlots }}
+                </v-list-item-subtitle>
+              </v-list-item>
+
+              <v-list-item v-if="sourceRunningEntries(node).length > 0" class="px-0 py-0 mt-1">
+                <template #prepend>
+                  <v-icon size="14" class="mr-1 text-medium-emphasis">mdi-database-sync</v-icon>
+                </template>
+                <v-list-item-subtitle class="text-caption">
+                  各源并发：{{ sourceRunningEntries(node).map(([k, v]) => `#${k}:${v}`).join('  ') }}
+                </v-list-item-subtitle>
+              </v-list-item>
+
+              <v-list-item class="px-0 py-0">
+                <template #prepend>
+                  <v-icon size="14" class="mr-1 text-medium-emphasis">mdi-clock-outline</v-icon>
+                </template>
+                <v-list-item-subtitle class="text-caption">
+                  最近心跳：{{ formatLastSeen(node.lastSeen) }}
+                </v-list-item-subtitle>
+              </v-list-item>
+            </v-list>
+          </v-card-text>
+        </v-card>
+      </v-col>
+
+      <!-- empty state -->
+      <v-col v-if="!loading && status.nodes.length === 0" cols="12">
+        <v-empty-state
+          icon="mdi-server-off"
+          title="暂无在线节点"
+          text="没有节点上报心跳，请检查服务是否正常运行。"
+        />
+      </v-col>
+    </v-row>
+
+    <div class="text-caption text-medium-emphasis mt-4 text-right">
+      上次刷新：{{ lastRefresh }}
+    </div>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { clusterService, type ClusterStatus, type WorkerNode } from '@/service/cluster-service'
+
+const loading = ref(false)
+const error = ref('')
+const lastRefresh = ref('')
+let timer: number | null = null
+
+const status = ref<ClusterStatus>({
+  nodes: [],
+  masterInstanceId: '',
+  totalNodes: 0,
+  timestamp: ''
+})
+
+const refresh = async () => {
+  loading.value = true
+  error.value = ''
+  try {
+    status.value = await clusterService.getNodes()
+    lastRefresh.value = new Date().toLocaleTimeString()
+  } catch (e: any) {
+    error.value = e?.message || '获取集群状态失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+const slotColor = (node: WorkerNode) => {
+  if (node.concurrentLimit === 0) return 'grey'
+  const ratio = node.running / node.concurrentLimit
+  if (ratio >= 0.9) return 'error'
+  if (ratio >= 0.7) return 'warning'
+  return 'success'
+}
+
+const sourceRunningEntries = (node: WorkerNode): [string, number][] => {
+  return Object.entries(node.sourceRunning ?? {}).filter(([, v]) => v > 0)
+}
+
+const formatLastSeen = (lastSeen: string | null): string => {
+  if (!lastSeen) return '—'
+  const d = new Date(lastSeen)
+  if (isNaN(d.getTime())) return lastSeen
+  const diffSecs = Math.round((Date.now() - d.getTime()) / 1000)
+  if (diffSecs < 60) return `${diffSecs}s 前`
+  return `${Math.round(diffSecs / 60)}m 前`
+}
+
+onMounted(() => {
+  refresh()
+  timer = window.setInterval(refresh, 15000)
+})
+
+onUnmounted(() => {
+  if (timer) window.clearInterval(timer)
+})
+</script>
+
+<style scoped>
+.cluster-page {
+  background: rgb(var(--v-theme-surface));
+}
+.node-card {
+  transition: box-shadow 0.15s ease;
+}
+.node-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+.node-info-list .v-list-item {
+  min-height: 24px !important;
+}
+</style>
+
+<route lang="json">
+{
+  "meta": {
+    "title": "集群状态",
+    "icon": "mdi-server-network",
+    "requiresAuth": true
+  }
+}
+</route>


### PR DESCRIPTION
## Motivation

The old greedy dispatch filled the first worker's slots completely before moving to the next (e.g. 3 tasks, A(slots=5) B(slots=3) → all 3 go to A). This ignores the configured per-node concurrency weight and leads to uneven load.

## What Changed

**Dispatch algorithm (TaskQueueManagerV2Impl)**
- Replaced double for-loop with Smooth Weighted Round Robin (SWRR)
- Each dispatch iteration selects ONE worker via `selectWorkerSwrr()`, assigns ONE job, decrements its in-cycle slot counter
- Tasks are distributed proportionally to `node.concurrency.weight` across the full dispatch cycle
- Added `WorkerSlot` inner class for in-cycle mutable slot tracking (prevents over-dispatch within one cycle while heartbeat data is stale)
- `swrrCurrentWeight` map persists between cycles for smooth long-run distribution
- Cleaned up on `onLostMaster()` / when workers leave

**Dead-worker recovery (also included)**
- `knownWorkerIds` diff in every dispatch cycle: workers that disappear are recovered within ~48s
- `recoverOrphanedJobs()` scheduled 30s after `onBecameMaster()`: handles cluster-restart orphans
- `orphanRecoverFuture` cancelled on `onLostMaster()` to prevent spurious recovery

**EtlJobQueueService**
- Added `releaseClaimedByInstance(instanceId)`
- Added `releaseOrphanedJobs(aliveInstanceIds)`

**Frontend**
- Restored accidentally-deleted `ClusterController.java`, `cluster-service.ts`, `cluster.vue`
- Added "集群状态" entry to navigation bar

## Validation

Tested with 2 nodes: A (weight=1.0), B (weight=0.6).  
Observed dispatch sequence: `A B A A B A B A A`  
Expected SWRR sequence:     `A B A A B A B A A` ✅  
8-round period: A×5, B×3 = 5:3 ratio matches weights exactly.

## Risks / Caveats

- `swrrCurrentWeight` is in-memory only; on master failover the new master starts fresh (weights converge after a few cycles — acceptable)
- Source-level concurrency check still uses heartbeat data with up to 15s staleness (unchanged from before)