### PR TITLE
fix: handle Redis connection factory stopped during shutdown

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/redis/WorkerHeartbeatService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/redis/WorkerHeartbeatService.java
@@ -96,6 +96,11 @@ public class WorkerHeartbeatService
         try {
             redisTemplate.delete(WORKER_KEY_PREFIX + electionService.getInstanceId());
         }
+        catch (IllegalStateException e) {
+            // During Spring shutdown, Redis connection factory may be stopped before this bean's
+            // @PreDestroy is called. Redis keys with TTL will auto-expire, so it's safe to skip.
+            log.debug("Redis connection factory stopped during shutdown, skipping heartbeat removal", e);
+        }
         catch (Exception e) {
             log.warn("Failed to remove own heartbeat key", e);
         }


### PR DESCRIPTION
The issue occurs when Spring's shutdown hook destroys the Redis connection factory before calling @PreDestroy on `TaskQueueManagerV2Impl`, which attempts to clean up the worker heartbeat key. Since Redis keys have TTL, skipping the removal is safe and doesn't affect functionality.

- Catch IllegalStateException when connection factory is stopped
- Skip heartbeat removal during shutdown since Redis TTL will auto-expire keys
- This fixes intermittent startup failures caused by bean destruction order races
- Change level to DEBUG for this expected scenario to reduce log noise

