### PR TITLE
fix(queue): stop rescheduling killed collect tasks

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java
@@ -3,13 +3,6 @@ package com.wgzhao.addax.admin.service;
 import com.wgzhao.addax.admin.model.EtlJobQueue;
 import com.wgzhao.addax.admin.model.EtlTable;
 import com.wgzhao.addax.admin.repository.EtlJobQueueRepo;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -18,6 +11,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @Slf4j
@@ -105,7 +105,7 @@ public class EtlJobQueueService
     @Transactional
     public void completeSuccess(long jobId)
     {
-        String sql = "UPDATE public.etl_job_queue SET status='completed', lease_until=NULL, claimed_by=NULL, claimed_at=NULL, last_error=NULL WHERE id=?";
+        String sql = "UPDATE public.etl_job_queue SET status='completed', lease_until=NULL, claimed_by=NULL, claimed_at=NULL, last_error=NULL WHERE id=? AND status='running'";
         jdbcTemplate.update(sql, jobId);
     }
 
@@ -133,7 +133,7 @@ public class EtlJobQueueService
                     UPDATE public.etl_job_queue
                     SET status='pending', available_at = now() + ?::interval,
                         lease_until=NULL, claimed_by=NULL, claimed_at=NULL, last_error=?
-                    WHERE id=?
+                    WHERE id=? AND status='running'
                 """;
             String interval = backoff.getSeconds() + " seconds";
             jdbcTemplate.update(sql, interval, truncateError(error), job.getId());
@@ -142,10 +142,21 @@ public class EtlJobQueueService
             String sql = """
                     UPDATE public.etl_job_queue
                     SET status='failed', lease_until=NULL, claimed_by=NULL, claimed_at=NULL, last_error=?
-                    WHERE id=?
+                    WHERE id=? AND status='running'
                 """;
             jdbcTemplate.update(sql, truncateError(error), job.getId());
         }
+    }
+
+    @Transactional
+    public void completeCancelled(long jobId, String reason)
+    {
+        String sql = """
+                UPDATE public.etl_job_queue
+                SET status='cancelled', lease_until=NULL, claimed_by=NULL, claimed_at=NULL, last_error=?
+                WHERE id=? AND status='running'
+            """;
+        jdbcTemplate.update(sql, truncateError(reason), jobId);
     }
 
     private String truncateError(String error)

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/ExecutionManager.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/ExecutionManager.java
@@ -2,6 +2,13 @@ package com.wgzhao.addax.admin.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -11,9 +18,6 @@ import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * ExecutionManager: manage running processes on this node and coordinate cross-node kill via Redis pub/sub.
@@ -27,6 +31,8 @@ public class ExecutionManager
     private static final String KILL_CHANNEL = "etl:kill";
     // in-memory registry of collecting table(s) on this instance
     private final ConcurrentHashMap<Long, ProcessHolder> running = new ConcurrentHashMap<>();
+    // Tracks tasks explicitly killed by user so worker can avoid rescheduling them as normal failures.
+    private final ConcurrentHashMap<Long, Instant> killRequested = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RedisMessageListenerContainer listenerContainer;
 
@@ -79,14 +85,106 @@ public class ExecutionManager
             return false;
         }
         try {
+            killRequested.put(tid, Instant.now());
             Process p = holder.process();
             log.warn("Killing local collecting table {} , pid={} requested", tid, holder.pid());
-            p.destroyForcibly();
+
+            ProcessHandle root = p.toHandle();
+            List<ProcessHandle> descendants = new ArrayList<>(root.descendants().toList());
+            descendants.sort(Comparator.comparingLong(this::depth).reversed());
+
+            int gracefulStopped = 0;
+            for (ProcessHandle handle : descendants) {
+                if (tryStopHandle(handle, false)) {
+                    gracefulStopped++;
+                }
+            }
+            if (tryStopHandle(root, false)) {
+                gracefulStopped++;
+            }
+
+            int forcedStopped = 0;
+            for (ProcessHandle handle : descendants) {
+                if (tryStopHandle(handle, true)) {
+                    forcedStopped++;
+                }
+            }
+            if (tryStopHandle(root, true)) {
+                forcedStopped++;
+            }
+
+            String marker = "-DjobName=" + tid;
+            int markerStopped = 0;
+            List<ProcessHandle> all = ProcessHandle.allProcesses().toList();
+            for (ProcessHandle handle : all) {
+                if (!handle.isAlive()) {
+                    continue;
+                }
+                if (handle.pid() == root.pid()) {
+                    continue;
+                }
+                String cmdLine = handle.info().commandLine().orElse("");
+                if (cmdLine.contains(marker) && tryStopHandle(handle, true)) {
+                    markerStopped++;
+                }
+            }
+
+            log.warn("Kill requested tid={} rootPid={} descendants={} gracefulStopped={} forcedStopped={} markerStopped={}",
+                tid, root.pid(), descendants.size(), gracefulStopped, forcedStopped, markerStopped);
             return true;
         }
         catch (Exception e) {
             log.error("Failed to kill local collecting table {} ", tid, e);
             return false;
+        }
+    }
+
+    /**
+     * Returns true once when a kill request has been recorded for this tid.
+     */
+    public boolean consumeKillRequested(long tid)
+    {
+        return killRequested.remove(tid) != null;
+    }
+
+    private long depth(ProcessHandle handle)
+    {
+        long d = 0;
+        Optional<ProcessHandle> p = handle.parent();
+        while (p.isPresent()) {
+            d++;
+            p = p.get().parent();
+        }
+        return d;
+    }
+
+    private boolean tryStopHandle(ProcessHandle handle, boolean force)
+    {
+        if (handle == null || !handle.isAlive()) {
+            return false;
+        }
+        try {
+            if (force) {
+                handle.destroyForcibly();
+            }
+            else {
+                handle.destroy();
+            }
+            waitExit(handle, 1200);
+            return true;
+        }
+        catch (Exception e) {
+            log.debug("Failed to stop pid={} force={}", handle.pid(), force, e);
+            return false;
+        }
+    }
+
+    private void waitExit(ProcessHandle handle, long millis)
+    {
+        try {
+            handle.onExit().get(millis, TimeUnit.MILLISECONDS);
+        }
+        catch (Exception ignored) {
         }
     }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -25,18 +25,6 @@ import com.wgzhao.addax.admin.service.UserNotificationService;
 import com.wgzhao.addax.admin.utils.CommandExecutor;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Primary;
-import org.springframework.data.redis.connection.Message;
-import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.data.redis.listener.ChannelTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Component;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -47,11 +35,11 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -63,6 +51,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
 
 import static com.wgzhao.addax.admin.common.Constants.ADDAX_EXECUTE_TIME_OUT_SECONDS;
 import static com.wgzhao.addax.admin.common.Constants.DEFAULT_PART_FORMAT;
@@ -277,6 +277,7 @@ public class TaskQueueManagerV2Impl
      * scanAndEnqueueEtlTasks: persists runnable tables into DB queue (DB-side, idempotent).
      * Only one node needs to do this, but it's safe if all do (unique constraint prevents duplicates).
      */
+    @Override
     public void scanAndEnqueueEtlTasks()
     {
         try {
@@ -545,7 +546,12 @@ public class TaskQueueManagerV2Impl
                 throw new IllegalStateException("Task not found tid=" + job.getTid());
             }
             taskResultDto = executeEtlTaskWithConcurrencyControl(task, job.getBizDate());
-            if (taskResultDto.success()) {
+            boolean killedByUser = executionManager.consumeKillRequested(job.getTid());
+            if (killedByUser) {
+                jobQueueService.completeCancelled(job.getId(), "Killed by user request");
+                log.info("Task killed by user, marked queue job {} as cancelled", job.getId());
+            }
+            else if (taskResultDto.success()) {
                 jobQueueService.completeSuccess(job.getId());
             }
             else {
@@ -555,8 +561,19 @@ public class TaskQueueManagerV2Impl
         }
         catch (Exception e) {
             log.error("Task execution failed jobId={} tid={}", job.getId(), job.getTid(), e);
-            Duration backoff = computeBackoff(job.getAttempts());
-            try { jobQueueService.failOrReschedule(job, e.getMessage(), backoff); } catch (Exception ignored) {}
+            boolean killedByUser = executionManager.consumeKillRequested(job.getTid());
+            if (killedByUser) {
+                try {
+                    jobQueueService.completeCancelled(job.getId(), "Killed by user request");
+                    log.info("Task killed by user during exception path, marked queue job {} as cancelled", job.getId());
+                }
+                catch (Exception ignored) {
+                }
+            }
+            else {
+                Duration backoff = computeBackoff(job.getAttempts());
+                try { jobQueueService.failOrReschedule(job, e.getMessage(), backoff); } catch (Exception ignored) {}
+            }
         }
         finally {
             if (renewer != null) {
@@ -627,6 +644,7 @@ public class TaskQueueManagerV2Impl
         }
     }
 
+    @Override
     public TaskResultDto executeEtlTaskWithConcurrencyControl(EtlTable task)
     {
         return executeEtlTaskWithConcurrencyControl(task, null);
@@ -671,21 +689,23 @@ public class TaskQueueManagerV2Impl
             return false;
         }
         String logName = String.format("%s.%s_%d.log", task.getTargetDb(), task.getTargetTable(), taskId);
-        String cmd = String.format("%s/bin/addax.sh  -p'-DjobName=%d -Dlog.file.name=%s' %s",
-            dictService.getAddaxHome(), taskId, logName, tempFile.getAbsolutePath());
-        boolean retCode = executeAddax(cmd, taskId, logName, task.getMaxRuntime() == null ? ADDAX_EXECUTE_TIME_OUT_SECONDS : task.getMaxRuntime());
+        String addaxScript = Path.of(dictService.getAddaxHome(), "bin", "addax.sh").toString();
+        String jvmProps = String.format("-DjobName=%d -Dlog.file.name=%s", taskId, logName);
+        List<String> cmdArgs = List.of(addaxScript, "-p", jvmProps, tempFile.getAbsolutePath());
+        String cmd = toCommandString(cmdArgs);
+        boolean retCode = executeAddax(cmdArgs, cmd, taskId, logName, task.getMaxRuntime() == null ? ADDAX_EXECUTE_TIME_OUT_SECONDS : task.getMaxRuntime());
         log.debug("Task {} log written to: {}", taskId, logName);
         return retCode;
     }
 
-    private boolean executeAddax(String command, long tid, String logName, long maxRuntimeSeconds)
+    private boolean executeAddax(List<String> commandArgs, String commandForLog, long tid, String logName, long maxRuntimeSeconds)
     {
-        EtlJour etlJour = jourService.addJour(tid, JourKind.COLLECT, command);
+        EtlJour etlJour = jourService.addJour(tid, JourKind.COLLECT, commandForLog);
         Process process;
         TaskResultDto taskResult;
         long pid = -1;
         try {
-            process = CommandExecutor.startProcess(command);
+            process = CommandExecutor.startProcess(commandArgs);
             try { pid = process.pid(); } catch (UnsupportedOperationException ignored) {}
             try {
                 executionManager.register(tid, process, pid, instanceId);
@@ -693,10 +713,10 @@ public class TaskQueueManagerV2Impl
             catch (Exception e) {
                 log.warn("Failed to register process in ExecutionManager tid={} pid={}", tid, pid, e);
             }
-            taskResult = CommandExecutor.waitForProcessWithResult(process, maxRuntimeSeconds, command);
+            taskResult = CommandExecutor.waitForProcessWithResult(process, maxRuntimeSeconds, commandForLog);
         }
         catch (IOException ioe) {
-            log.error("Failed to start process for command: {}", command, ioe);
+            log.error("Failed to start process for command: {}", commandForLog, ioe);
             taskResult = TaskResultDto.failure(ioe.getMessage(), 0);
         }
         finally {
@@ -715,6 +735,22 @@ public class TaskQueueManagerV2Impl
         }
         jourService.saveJour(etlJour);
         return taskResult.success();
+    }
+
+    private String toCommandString(List<String> args)
+    {
+        return args.stream().map(this::quoteForLog).collect(Collectors.joining(" "));
+    }
+
+    private String quoteForLog(String arg)
+    {
+        if (arg == null || arg.isBlank()) {
+            return "''";
+        }
+        if (arg.matches("[A-Za-z0-9_./:=@+-]+")) {
+            return arg;
+        }
+        return "'" + arg.replace("'", "'\"'\"'") + "'";
     }
 
     private void recoverLeases()
@@ -744,12 +780,14 @@ public class TaskQueueManagerV2Impl
 
     // ---- TaskQueueManager interface ----
 
+    @Override
     public void stopQueueMonitor()
     {
         running = false;
         cancelScheduledTasks();
     }
 
+    @Override
     public void restartQueueMonitor()
     {
         stopQueueMonitor();
@@ -758,6 +796,7 @@ public class TaskQueueManagerV2Impl
         submitScheduledTasks();
     }
 
+    @Override
     public boolean addTaskToQueue(@NonNull EtlTable etlTable)
     {
         if (!running) {
@@ -779,6 +818,7 @@ public class TaskQueueManagerV2Impl
         return jobQueueService.enqueue(etlTable, bizDate, 100, payload) > 0;
     }
 
+    @Override
     public boolean addTaskToQueue(long tableId)
     {
         EtlTable table = tableService.getTable(tableId);
@@ -792,6 +832,7 @@ public class TaskQueueManagerV2Impl
         return table != null && addTaskToQueue(table, payload);
     }
 
+    @Override
     public int clearQueue()
     {
         return jobQueueService.clearPending();
@@ -803,6 +844,7 @@ public class TaskQueueManagerV2Impl
         return !running;
     }
 
+    @Override
     public Map<String, Object> getQueueStatus()
     {
         Map<String, Object> status = new HashMap<>();
@@ -813,6 +855,7 @@ public class TaskQueueManagerV2Impl
         return status;
     }
 
+    @Override
     public void startQueueMonitor()
     {
         if (running) return;

--- a/backend/src/main/java/com/wgzhao/addax/admin/utils/CommandExecutor.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/utils/CommandExecutor.java
@@ -1,8 +1,6 @@
 package com.wgzhao.addax.admin.utils;
 
 import com.wgzhao.addax.admin.dto.TaskResultDto;
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,6 +8,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
 
 /**
  * 命令执行工具类。
@@ -18,6 +18,17 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class CommandExecutor
 {
+    /**
+     * Start a process with explicit command args and return the Process object.
+     */
+    public static Process startProcess(List<String> commandArgs)
+        throws IOException
+    {
+        ProcessBuilder pb = new ProcessBuilder(commandArgs);
+        pb.redirectErrorStream(true);
+        return pb.start();
+    }
+
     /**
      * Start a process for the given shell command and return the Process object.
      */


### PR DESCRIPTION
## Motivation / Background
Killing a running collect task could still trigger a re-run later because killed runs were treated as normal failures and rescheduled.

## What Changed
- Improved local kill to terminate process tree and fallback cleanup by -DjobName marker.
- Added kill-request tracking in ExecutionManager with one-time consumption in worker flow.
- Added completeCancelled(jobId, reason) in EtlJobQueueService.
- Added status=running guards to queue success/failure transitions.
- Mark user-killed jobs as cancelled instead of failOrReschedule.

## Validation
- bun build:backend (BUILD SUCCESS)
- Manual test passed: killed task no longer returns to pending or gets redispatched.
