### PR TITLE
(feat):  Reduce claim/release thrash in master dispatch

### DIFF
--- a/PR-claim-release-thrash.md
+++ b/PR-claim-release-thrash.md
@@ -1,0 +1,64 @@
+# PR: Reduce claim/release thrash in master dispatch
+
+**Branch:** `feat/reduce-claim-release-thrash`  
+**Commit:** `d74110d`  
+**Validation:** `mvn -q -DskipTests -pl backend clean package`
+
+## Motivation / Background
+
+In the master-worker dispatch flow, the master previously claimed a pending job first and only then checked whether the selected worker still had enough global/source concurrency capacity.
+
+When a job did not fit the current worker ledger, the master would immediately release it back to the queue. This created unnecessary claim/release churn and caused the same jobs to be repeatedly picked and dropped across dispatch cycles.
+
+## What Changed
+
+### `backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java`
+
+Added two new queue operations:
+
+- `peekPendingJobs(int limit)`
+  - Read-only view of eligible pending jobs.
+  - Does not change queue state.
+
+- `assignSpecificJobToWorker(long jobId, String targetInstanceId, int leaseSeconds)`
+  - Atomically claims a specific pending job.
+  - Keeps the actual state transition transactional and targeted.
+
+### `backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java`
+
+Reworked master dispatch to use a two-step flow:
+
+1. Peek pending jobs without changing queue state.
+2. Evaluate whether each job is feasible for the selected worker using the master-side ledger.
+3. Only then atomically claim the specific job.
+
+This preserves the existing:
+
+- master-side authoritative concurrency ledger
+- SWRR worker selection
+- heartbeat reconciliation
+
+while removing the main source of claim/release thrash.
+
+## Design / Implementation Notes
+
+- The master still owns concurrency decisions.
+- Heartbeat data remains a reconciliation input, not the sole source of truth.
+- The dispatch loop now filters jobs before claiming them.
+- If Redis pub/sub delivery fails after claim, the job is still released as a safety fallback.
+
+## Validation
+
+Successfully built the backend with:
+
+```bash
+mvn -q -DskipTests -pl backend clean package
+```
+
+## Risks / Caveats / Follow-ups
+
+- This change reduces queue thrash, but it does not completely eliminate all release paths:
+  - Redis publish failure still falls back to `releaseClaim()`.
+- The peek limit is currently bounded by `PENDING_JOB_PEEK_LIMIT` in `TaskQueueManagerV2Impl`.
+  - If the queue becomes very large or worker selection patterns change, this limit may need tuning.
+- This branch intentionally stays focused on reducing dispatch churn and does not change unrelated scheduling behavior.

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java
@@ -102,6 +102,46 @@ public class EtlJobQueueService
         return list.isEmpty() ? Optional.empty() : Optional.of(list.getFirst());
     }
 
+    /**
+     * Read-only peek at pending jobs without changing queue state.
+     */
+    @Transactional(readOnly = true)
+    public List<EtlJobQueue> peekPendingJobs(int limit)
+    {
+        String sql = """
+            SELECT *
+            FROM public.etl_job_queue
+            WHERE status='pending' AND available_at <= now()
+            ORDER BY priority, available_at, id
+            LIMIT ?
+            """;
+        return jdbcTemplate.query(sql, JOB_ROW_MAPPER, Math.max(1, limit));
+    }
+
+    /**
+     * Master-mode: atomically claim a specific pending job and assign it to a worker instance.
+     */
+    @Transactional
+    public Optional<EtlJobQueue> assignSpecificJobToWorker(long jobId, String targetInstanceId, int leaseSeconds)
+    {
+        String sql = """
+            WITH cte AS (
+                SELECT id
+                FROM public.etl_job_queue
+                WHERE id=? AND status='pending' AND available_at <= now()
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE public.etl_job_queue q
+            SET status='running', claimed_by=?, claimed_at=now(), lease_until=now() + ?::interval, attempts=attempts+1
+            FROM cte
+            WHERE q.id = cte.id
+            RETURNING q.*
+            """;
+        String leaseInterval = leaseSeconds + " seconds";
+        List<EtlJobQueue> list = jdbcTemplate.query(sql, JOB_ROW_MAPPER, jobId, targetInstanceId, leaseInterval);
+        return list.isEmpty() ? Optional.empty() : Optional.of(list.getFirst());
+    }
+
     @Transactional
     public void completeSuccess(long jobId)
     {

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -32,8 +32,10 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +43,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Deque;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -138,6 +141,8 @@ public class TaskQueueManagerV2Impl
 
     // SWRR state: master-only, tracks accumulated weight per worker between dispatch cycles
     private final ConcurrentHashMap<String, Double> swrrCurrentWeight = new ConcurrentHashMap<>();
+    // Master-side worker capacity ledger between heartbeat snapshots
+    private final ConcurrentHashMap<String, WorkerLedger> workerLedgers = new ConcurrentHashMap<>();
     // Tracks alive workers seen in the previous dispatch cycle for dead-worker detection
     private final Set<String> knownWorkerIds = new HashSet<>();
 
@@ -201,6 +206,7 @@ public class TaskQueueManagerV2Impl
     private void onBecameMaster()
     {
         log.info("Became master — starting dispatch loop");
+        workerLedgers.clear();
         knownWorkerIds.clear();
         // Wait 2× heartbeat interval for workers to re-register, then release orphaned tasks
         if (orphanRecoverFuture != null) orphanRecoverFuture.cancel(false);
@@ -212,6 +218,7 @@ public class TaskQueueManagerV2Impl
     {
         log.info("Lost master role — pausing dispatch (workers continue executing current tasks)");
         swrrCurrentWeight.clear();
+        workerLedgers.clear();
         knownWorkerIds.clear();
         if (orphanRecoverFuture != null) {
             orphanRecoverFuture.cancel(false);
@@ -396,25 +403,35 @@ public class TaskQueueManagerV2Impl
         // Clean up SWRR state for workers that are no longer alive
         swrrCurrentWeight.keySet().retainAll(currentWorkerIds);
 
-        // Mutable per-cycle slot snapshot to prevent over-dispatching within one cycle
-        // (heartbeat data is stale by up to HEARTBEAT_INTERVAL_SECONDS)
+        // Reconcile the master's capacity ledger with the latest heartbeat snapshot.
+        // The ledger is mutated on every successful assignment, so dispatch cycles do not
+        // depend on heartbeat freshness alone.
         List<WorkerSlot> slots = workers.stream()
-            .map(w -> new WorkerSlot(w, w.availableSlots()))
+            .map(w -> {
+                WorkerLedger ledger = workerLedgers.compute(w.instanceId(), (id, existing) -> {
+                    if (existing == null) {
+                        return new WorkerLedger(w);
+                    }
+                    existing.reconcile(w);
+                    return existing;
+                });
+                return new WorkerSlot(ledger);
+            })
             .collect(Collectors.toCollection(java.util.ArrayList::new));
 
         while (true) {
             WorkerSlot selected = selectWorkerSwrr(slots);
             if (selected == null) return; // all workers have no available slots
 
-            Optional<EtlJobQueue> maybe = jobQueueService.assignToWorker(selected.worker.instanceId(), DEFAULT_LEASE_SECONDS);
+            Optional<EtlJobQueue> maybe = jobQueueService.assignToWorker(selected.instanceId(), DEFAULT_LEASE_SECONDS);
             if (maybe.isEmpty()) return; // no more pending jobs
 
             EtlJobQueue job = maybe.get();
 
             // Check 1: global node concurrency limit
-            if (selected.worker.running() >= selected.worker.concurrentLimit()) {
+            if (selected.running() >= selected.concurrentLimit()) {
                 log.warn("Check1 global limit reached for worker {}: running={} >= limit={}, releasing job {}",
-                    selected.worker.instanceId(), selected.worker.running(), selected.worker.concurrentLimit(), job.getId());
+                    selected.instanceId(), selected.running(), selected.concurrentLimit(), job.getId());
                 jobQueueService.releaseClaim(job.getId(), 5);
                 selected.slots = 0;
                 continue;
@@ -422,45 +439,47 @@ public class TaskQueueManagerV2Impl
 
             // Check 2: source-level concurrency limit, with global limit as upper bound
             EtlTable table = tableService.getTable(job.getTid());
+            Integer trackedSid = null;
             if (table != null) {
                 VwEtlTableWithSource source = tableService.getTableView(table.getId());
                 if (source != null && source.getMaxConcurrency() != null && source.getMaxConcurrency() > 0) {
                     int effectiveLimit = Math.max(1, Math.min(
-                        (int) Math.floor(source.getMaxConcurrency() * selected.worker.weight()),
-                        selected.worker.concurrentLimit()
+                        (int) Math.floor(source.getMaxConcurrency() * selected.weight()),
+                        selected.concurrentLimit()
                     ));
                     int workerSrcRunning = selected.sourceRunning(table.getSid());
                     if (workerSrcRunning >= effectiveLimit) {
-                        log.warn("Check2 source limit reached: source={} sid={} worker={}, job={} cycleRunning={} heartbeatRunning={} effectiveLimit={}",
-                            source.getCode(), table.getSid(), selected.worker.instanceId(), job.getId(),
-                            selected.cycleSourceRunning.getOrDefault(table.getSid(), 0),
-                            selected.worker.sourceRunning().getOrDefault(table.getSid(), 0),
+                        log.warn("Check2 source limit reached: source={} sid={} worker={}, job={} effectiveRunning={} heartbeatRunning={} effectiveLimit={}",
+                            source.getCode(), table.getSid(), selected.instanceId(), job.getId(),
+                            workerSrcRunning,
+                            selected.heartbeatRunning(),
                             effectiveLimit);
                         jobQueueService.releaseClaim(job.getId(), 5);
                         try { tableService.setWaiting(table); } catch (Exception ignored) {}
                         selected.slots = 0;
                         continue;
                     }
+                    trackedSid = table.getSid();
                 }
             }
 
             // Publish job to worker's channel
             try {
                 String assignPayload = objectMapper.writeValueAsString(job);
-                String channel = TASK_ASSIGN_CHANNEL_PREFIX + selected.worker.instanceId();
+                String channel = TASK_ASSIGN_CHANNEL_PREFIX + selected.instanceId();
+                int runningBefore = selected.running();
+                int sourceRunningBefore = trackedSid != null ? selected.sourceRunning(trackedSid) : -1;
                 stringRedisTemplate.convertAndSend(channel, assignPayload);
-                log.info("Assigned job {} (tid={}) to worker {} [source sid={} cycleRunning={}, globalRunning={}/{}]",
-                    job.getId(), job.getTid(), selected.worker.instanceId(),
+                selected.reserve(trackedSid);
+                log.info("Assigned job {} (tid={}) to worker {} [source sid={} sourceRunning={} globalRunning={}/{}]",
+                    job.getId(), job.getTid(), selected.instanceId(),
                     table != null ? table.getSid() : "-",
-                    table != null ? selected.cycleSourceRunning.getOrDefault(table.getSid(), 0) : "-",
-                    selected.worker.running(), selected.worker.concurrentLimit());
+                    trackedSid != null ? sourceRunningBefore : "-",
+                    runningBefore, selected.concurrentLimit());
                 selected.slots--;
-                if (table != null) {
-                    selected.incrementSource(table.getSid()); // track in-cycle source assignment
-                }
             }
             catch (Exception e) {
-                log.error("Failed to publish task assignment for jobId={} to worker={}", job.getId(), selected.worker.instanceId(), e);
+                log.error("Failed to publish task assignment for jobId={} to worker={}", job.getId(), selected.instanceId(), e);
                 try { jobQueueService.releaseClaim(job.getId(), 5); } catch (Exception ignored) {}
             }
         }
@@ -477,11 +496,11 @@ public class TaskQueueManagerV2Impl
     {
         if (slots.isEmpty()) return null;
 
-        double totalWeight = slots.stream().mapToDouble(s -> s.worker.weight()).sum();
+        double totalWeight = slots.stream().mapToDouble(WorkerSlot::weight).sum();
 
         // Step 1: every worker accumulates its configured weight
         for (WorkerSlot s : slots) {
-            swrrCurrentWeight.merge(s.worker.instanceId(), s.worker.weight(), Double::sum);
+            swrrCurrentWeight.merge(s.instanceId(), s.weight(), Double::sum);
         }
 
         // Step 2: select the worker with the highest accumulated weight that has a free slot
@@ -489,7 +508,7 @@ public class TaskQueueManagerV2Impl
         double maxCw = Double.NEGATIVE_INFINITY;
         for (WorkerSlot s : slots) {
             if (s.slots <= 0) continue;
-            double cw = swrrCurrentWeight.getOrDefault(s.worker.instanceId(), 0.0);
+            double cw = swrrCurrentWeight.getOrDefault(s.instanceId(), 0.0);
             if (cw > maxCw) {
                 maxCw = cw;
                 selected = s;
@@ -499,36 +518,138 @@ public class TaskQueueManagerV2Impl
         if (selected == null) return null;
 
         // Step 3: deduct total weight from the selected worker
-        swrrCurrentWeight.merge(selected.worker.instanceId(), -totalWeight, Double::sum);
+        swrrCurrentWeight.merge(selected.instanceId(), -totalWeight, Double::sum);
 
         return selected;
     }
 
-    /** Per-cycle mutable slot tracker to prevent over-dispatching within a single masterDispatch() call. */
+    /** Worker capacity snapshot backed by the master's authoritative ledger. */
     private static final class WorkerSlot
     {
-        final WorkerHeartbeatService.WorkerInfo worker;
+        final WorkerLedger ledger;
         int slots;
-        // Track per-source assigned count within this dispatch cycle to prevent over-dispatching
-        // before the next heartbeat updates the stale sourceRunning snapshot.
-        final Map<Integer, Integer> cycleSourceRunning = new HashMap<>();
 
-        WorkerSlot(WorkerHeartbeatService.WorkerInfo worker, int slots)
+        WorkerSlot(WorkerLedger ledger)
         {
-            this.worker = worker;
-            this.slots = slots;
+            this.ledger = ledger;
+            this.slots = ledger.availableSlots();
+        }
+
+        String instanceId()
+        {
+            return ledger.instanceId();
+        }
+
+        double weight()
+        {
+            return ledger.weight();
+        }
+
+        int running()
+        {
+            return ledger.running();
+        }
+
+        int heartbeatRunning()
+        {
+            return ledger.heartbeatRunning();
+        }
+
+        int concurrentLimit()
+        {
+            return ledger.concurrentLimit();
         }
 
         int sourceRunning(int sid)
         {
-            return worker.sourceRunning().getOrDefault(sid, 0)
-                + cycleSourceRunning.getOrDefault(sid, 0);
+            return ledger.sourceRunning(sid);
         }
 
-        void incrementSource(int sid)
+        void reserve(Integer sid)
         {
-            cycleSourceRunning.merge(sid, 1, Integer::sum);
+            ledger.reserve(sid);
         }
+    }
+
+    private static final class WorkerLedger
+    {
+        private WorkerHeartbeatService.WorkerInfo heartbeat;
+        private Instant heartbeatSeenAt;
+        private int reservedRunning;
+        private final Map<Integer, Integer> reservedSourceRunning = new HashMap<>();
+        private final Deque<Reservation> reservations = new ArrayDeque<>();
+
+        WorkerLedger(WorkerHeartbeatService.WorkerInfo heartbeat)
+        {
+            this.heartbeat = heartbeat;
+            this.heartbeatSeenAt = heartbeat.lastSeen();
+        }
+
+        synchronized void reconcile(WorkerHeartbeatService.WorkerInfo info)
+        {
+            if (heartbeatSeenAt != null && !info.lastSeen().isAfter(heartbeatSeenAt)) {
+                return;
+            }
+            heartbeat = info;
+            heartbeatSeenAt = info.lastSeen();
+            while (!reservations.isEmpty() && !reservations.peekFirst().reservedAt().isAfter(heartbeatSeenAt)) {
+                Reservation reservation = reservations.removeFirst();
+                reservedRunning = Math.max(0, reservedRunning - 1);
+                if (reservation.sid() != null) {
+                    reservedSourceRunning.computeIfPresent(reservation.sid(), (k, v) -> v <= 1 ? null : v - 1);
+                }
+            }
+        }
+
+        synchronized String instanceId()
+        {
+            return heartbeat.instanceId();
+        }
+
+        synchronized double weight()
+        {
+            return heartbeat.weight();
+        }
+
+        synchronized int concurrentLimit()
+        {
+            return heartbeat.concurrentLimit();
+        }
+
+        synchronized int heartbeatRunning()
+        {
+            return heartbeat.running();
+        }
+
+        synchronized int running()
+        {
+            return heartbeat.running() + reservedRunning;
+        }
+
+        synchronized int availableSlots()
+        {
+            return Math.max(0, concurrentLimit() - running());
+        }
+
+        synchronized int sourceRunning(int sid)
+        {
+            return heartbeat.sourceRunning().getOrDefault(sid, 0)
+                + reservedSourceRunning.getOrDefault(sid, 0);
+        }
+
+        synchronized void reserve(Integer sid)
+        {
+            Reservation reservation = new Reservation(sid, Instant.now());
+            reservations.addLast(reservation);
+            reservedRunning++;
+            if (sid != null) {
+                reservedSourceRunning.merge(sid, 1, Integer::sum);
+            }
+        }
+    }
+
+    private record Reservation(Integer sid, Instant reservedAt)
+    {
     }
 
     private void triggerDispatchAsync()

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -411,20 +411,33 @@ public class TaskQueueManagerV2Impl
 
             EtlJobQueue job = maybe.get();
 
-            // Check source-level concurrency via worker's heartbeat data
+            // Check 1: global node concurrency limit
+            if (selected.worker.running() >= selected.worker.concurrentLimit()) {
+                log.warn("Check1 global limit reached for worker {}: running={} >= limit={}, releasing job {}",
+                    selected.worker.instanceId(), selected.worker.running(), selected.worker.concurrentLimit(), job.getId());
+                jobQueueService.releaseClaim(job.getId(), 5);
+                selected.slots = 0;
+                continue;
+            }
+
+            // Check 2: source-level concurrency limit, with global limit as upper bound
             EtlTable table = tableService.getTable(job.getTid());
             if (table != null) {
                 VwEtlTableWithSource source = tableService.getTableView(table.getId());
                 if (source != null && source.getMaxConcurrency() != null && source.getMaxConcurrency() > 0) {
-                    int effectiveLimit = Math.max(1, (int) Math.floor(source.getMaxConcurrency() * selected.worker.weight()));
-                    int workerSrcRunning = selected.worker.sourceRunning().getOrDefault(table.getSid(), 0);
+                    int effectiveLimit = Math.max(1, Math.min(
+                        (int) Math.floor(source.getMaxConcurrency() * selected.worker.weight()),
+                        selected.worker.concurrentLimit()
+                    ));
+                    int workerSrcRunning = selected.sourceRunning(table.getSid());
                     if (workerSrcRunning >= effectiveLimit) {
-                        log.debug("Source {} concurrency limit reached for worker {}, releasing job {}",
-                            source.getCode(), selected.worker.instanceId(), job.getId());
+                        log.warn("Check2 source limit reached: source={} sid={} worker={}, job={} cycleRunning={} heartbeatRunning={} effectiveLimit={}",
+                            source.getCode(), table.getSid(), selected.worker.instanceId(), job.getId(),
+                            selected.cycleSourceRunning.getOrDefault(table.getSid(), 0),
+                            selected.worker.sourceRunning().getOrDefault(table.getSid(), 0),
+                            effectiveLimit);
                         jobQueueService.releaseClaim(job.getId(), 5);
                         try { tableService.setWaiting(table); } catch (Exception ignored) {}
-                        // Zero out this worker's slot so SWRR won't select it again this cycle;
-                        // a fresh dispatch cycle will re-evaluate once heartbeat is updated
                         selected.slots = 0;
                         continue;
                     }
@@ -436,8 +449,15 @@ public class TaskQueueManagerV2Impl
                 String assignPayload = objectMapper.writeValueAsString(job);
                 String channel = TASK_ASSIGN_CHANNEL_PREFIX + selected.worker.instanceId();
                 stringRedisTemplate.convertAndSend(channel, assignPayload);
-                log.info("Assigned job {} (tid={}) to worker {}", job.getId(), job.getTid(), selected.worker.instanceId());
-                selected.slots--; // deduct in-cycle to avoid over-dispatching to same worker
+                log.info("Assigned job {} (tid={}) to worker {} [source sid={} cycleRunning={}, globalRunning={}/{}]",
+                    job.getId(), job.getTid(), selected.worker.instanceId(),
+                    table != null ? table.getSid() : "-",
+                    table != null ? selected.cycleSourceRunning.getOrDefault(table.getSid(), 0) : "-",
+                    selected.worker.running(), selected.worker.concurrentLimit());
+                selected.slots--;
+                if (table != null) {
+                    selected.incrementSource(table.getSid()); // track in-cycle source assignment
+                }
             }
             catch (Exception e) {
                 log.error("Failed to publish task assignment for jobId={} to worker={}", job.getId(), selected.worker.instanceId(), e);
@@ -489,11 +509,25 @@ public class TaskQueueManagerV2Impl
     {
         final WorkerHeartbeatService.WorkerInfo worker;
         int slots;
+        // Track per-source assigned count within this dispatch cycle to prevent over-dispatching
+        // before the next heartbeat updates the stale sourceRunning snapshot.
+        final Map<Integer, Integer> cycleSourceRunning = new HashMap<>();
 
         WorkerSlot(WorkerHeartbeatService.WorkerInfo worker, int slots)
         {
             this.worker = worker;
             this.slots = slots;
+        }
+
+        int sourceRunning(int sid)
+        {
+            return worker.sourceRunning().getOrDefault(sid, 0)
+                + cycleSourceRunning.getOrDefault(sid, 0);
+        }
+
+        void incrementSource(int sid)
+        {
+            cycleSourceRunning.merge(sid, 1, Integer::sum);
         }
     }
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java
@@ -94,6 +94,7 @@ public class TaskQueueManagerV2Impl
     private static final int DEFAULT_POLL_INTERVAL_SECONDS = 3;
     private static final int DEFAULT_LEASE_SECONDS = 7300;
     private static final int HEARTBEAT_INTERVAL_SECONDS = 15;
+    private static final int PENDING_JOB_PEEK_LIMIT = 200;
     // Redis channel for task assignment: master → worker
     private static final String TASK_ASSIGN_CHANNEL_PREFIX = "addax:task:assign:";
 
@@ -418,50 +419,25 @@ public class TaskQueueManagerV2Impl
                 return new WorkerSlot(ledger);
             })
             .collect(Collectors.toCollection(java.util.ArrayList::new));
+        List<EtlJobQueue> pendingJobs = jobQueueService.peekPendingJobs(PENDING_JOB_PEEK_LIMIT);
+        if (pendingJobs.isEmpty()) {
+            return;
+        }
 
+        Set<Long> consumedJobIds = new HashSet<>();
         while (true) {
             WorkerSlot selected = selectWorkerSwrr(slots);
             if (selected == null) return; // all workers have no available slots
 
-            Optional<EtlJobQueue> maybe = jobQueueService.assignToWorker(selected.instanceId(), DEFAULT_LEASE_SECONDS);
-            if (maybe.isEmpty()) return; // no more pending jobs
-
-            EtlJobQueue job = maybe.get();
-
-            // Check 1: global node concurrency limit
-            if (selected.running() >= selected.concurrentLimit()) {
-                log.warn("Check1 global limit reached for worker {}: running={} >= limit={}, releasing job {}",
-                    selected.instanceId(), selected.running(), selected.concurrentLimit(), job.getId());
-                jobQueueService.releaseClaim(job.getId(), 5);
+            Optional<JobClaim> maybe = findClaimableJobForWorker(selected, pendingJobs, consumedJobIds);
+            if (maybe.isEmpty()) {
                 selected.slots = 0;
                 continue;
             }
 
-            // Check 2: source-level concurrency limit, with global limit as upper bound
-            EtlTable table = tableService.getTable(job.getTid());
-            Integer trackedSid = null;
-            if (table != null) {
-                VwEtlTableWithSource source = tableService.getTableView(table.getId());
-                if (source != null && source.getMaxConcurrency() != null && source.getMaxConcurrency() > 0) {
-                    int effectiveLimit = Math.max(1, Math.min(
-                        (int) Math.floor(source.getMaxConcurrency() * selected.weight()),
-                        selected.concurrentLimit()
-                    ));
-                    int workerSrcRunning = selected.sourceRunning(table.getSid());
-                    if (workerSrcRunning >= effectiveLimit) {
-                        log.warn("Check2 source limit reached: source={} sid={} worker={}, job={} effectiveRunning={} heartbeatRunning={} effectiveLimit={}",
-                            source.getCode(), table.getSid(), selected.instanceId(), job.getId(),
-                            workerSrcRunning,
-                            selected.heartbeatRunning(),
-                            effectiveLimit);
-                        jobQueueService.releaseClaim(job.getId(), 5);
-                        try { tableService.setWaiting(table); } catch (Exception ignored) {}
-                        selected.slots = 0;
-                        continue;
-                    }
-                    trackedSid = table.getSid();
-                }
-            }
+            JobClaim claim = maybe.get();
+            EtlJobQueue job = claim.job();
+            Integer trackedSid = claim.trackedSid();
 
             // Publish job to worker's channel
             try {
@@ -473,16 +449,80 @@ public class TaskQueueManagerV2Impl
                 selected.reserve(trackedSid);
                 log.info("Assigned job {} (tid={}) to worker {} [source sid={} sourceRunning={} globalRunning={}/{}]",
                     job.getId(), job.getTid(), selected.instanceId(),
-                    table != null ? table.getSid() : "-",
-                    trackedSid != null ? sourceRunningBefore : "-",
+                    trackedSid != null ? String.valueOf(trackedSid) : "-",
+                    trackedSid != null ? String.valueOf(sourceRunningBefore) : "-",
                     runningBefore, selected.concurrentLimit());
                 selected.slots--;
+                consumedJobIds.add(job.getId());
             }
             catch (Exception e) {
                 log.error("Failed to publish task assignment for jobId={} to worker={}", job.getId(), selected.instanceId(), e);
+                consumedJobIds.add(job.getId());
                 try { jobQueueService.releaseClaim(job.getId(), 5); } catch (Exception ignored) {}
             }
         }
+    }
+
+    /**
+     * Find the first pending job that is still feasible for the selected worker and claim it atomically.
+     */
+    private Optional<JobClaim> findClaimableJobForWorker(WorkerSlot selected,
+                                                         List<EtlJobQueue> candidates,
+                                                         Set<Long> consumedJobIds)
+    {
+        for (EtlJobQueue candidate : candidates) {
+            long jobId = candidate.getId();
+            if (consumedJobIds.contains(jobId)) {
+                continue;
+            }
+
+            JobCheck check = assessJobForWorker(selected, candidate);
+            if (!check.assignable()) {
+                continue;
+            }
+
+            Optional<EtlJobQueue> claimed = jobQueueService.assignSpecificJobToWorker(
+                jobId, selected.instanceId(), DEFAULT_LEASE_SECONDS);
+            if (claimed.isPresent()) {
+                consumedJobIds.add(jobId);
+                return Optional.of(new JobClaim(claimed.get(), check.trackedSid()));
+            }
+
+            consumedJobIds.add(jobId);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Check whether the current worker ledger can still accept this job without claiming it first.
+     */
+    private JobCheck assessJobForWorker(WorkerSlot selected, EtlJobQueue job)
+    {
+        if (selected.running() >= selected.concurrentLimit()) {
+            return new JobCheck(false, null);
+        }
+
+        EtlTable table = tableService.getTable(job.getTid());
+        if (table == null) {
+            return new JobCheck(true, null);
+        }
+
+        VwEtlTableWithSource source = tableService.getTableView(table.getId());
+        if (source == null || source.getMaxConcurrency() == null || source.getMaxConcurrency() <= 0) {
+            return new JobCheck(true, null);
+        }
+
+        int effectiveLimit = Math.max(1, Math.min(
+            (int) Math.floor(source.getMaxConcurrency() * selected.weight()),
+            selected.concurrentLimit()
+        ));
+        int workerSrcRunning = selected.sourceRunning(table.getSid());
+        if (workerSrcRunning >= effectiveLimit) {
+            return new JobCheck(false, null);
+        }
+
+        return new JobCheck(true, table.getSid());
     }
 
     /**
@@ -521,6 +561,14 @@ public class TaskQueueManagerV2Impl
         swrrCurrentWeight.merge(selected.instanceId(), -totalWeight, Double::sum);
 
         return selected;
+    }
+
+    private record JobClaim(EtlJobQueue job, Integer trackedSid)
+    {
+    }
+
+    private record JobCheck(boolean assignable, Integer trackedSid)
+    {
     }
 
     /** Worker capacity snapshot backed by the master's authoritative ledger. */

--- a/memory.md
+++ b/memory.md
@@ -141,3 +141,70 @@ master-worker 架构迁移完成后，对全部调度相关代码进行综合 re
 2. 上一轮修复改为 `WHERE rn = 1 OR rn IS NULL`：修复了首次运行场景，但忽略了 LEFT JOIN 条件 `and t.status in ('R','W')` 会让非 R/W 表 rn=NULL，导致全表都被返回
 
 正确做法：外层加 `t.status IN ('R','W')` 过滤，内层保留 `OR rn IS NULL` 覆盖首次运行场景。
+
+---
+
+# 并发控制 Bug 修复
+
+> Date: 2026-05-23
+> Branch: `fix/concurrency-control-limit`
+> Build: ✅ BUILD SUCCESS（人工验证通过）
+
+## 背景
+
+master-worker 架构迁移后，`masterDispatch()` 中对采集源并发数的控制存在两个 bug，导致实际分配给节点的任务数超过 `etl_source.max_concurrency` 定义的上限。
+
+## Bug 清单
+
+| # | 严重等级 | 问题描述 | 涉及文件 | 修复方式 |
+|---|---------|---------|---------|----------|
+| 1 | 🔴 高 | 缺少全局节点并发检查：`masterDispatch()` 只检查采集源级限制，从未检查节点的 `CONCURRENT_LIMIT * weight` 上限，导致单节点运行任务数可无上限溢出 | `TaskQueueManagerV2Impl.java` | 在 Check 2 之前增加 Check 1：`worker.running >= worker.concurrentLimit` 时释放任务并跳过该 worker |
+| 2 | 🔴 高 | 采集源并发公式忽略全局上界：原公式 `effectiveLimit = source.maxConcurrency * weight`，当 `max_concurrency` 远大于 `CONCURRENT_LIMIT` 时，计算结果严重超限 | `TaskQueueManagerV2Impl.java` | 修正为 `effectiveLimit = min(source.maxConcurrency * weight, concurrentLimit)`，等价于 `min(source.max, CONCURRENT_LIMIT) * weight` |
+| 3 | 🔴 高 | 心跳快照陈旧导致单次 dispatch 周期内采集源并发超发：`masterDispatch()` 的 `while(true)` 内，每轮检查的 `sourceRunning` 均来自同一个心跳快照（最多 15 秒前），本轮已分配的任务数对下一次循环不可见，同一采集源可被无限分配 | `TaskQueueManagerV2Impl.java` | 在 `WorkerSlot` 内新增 `cycleSourceRunning` map 作为本轮增量计数器；`sourceRunning(sid)` 方法返回心跳快照值 + 本轮已分配数；每次分配成功后调用 `incrementSource(sid)` 递增 |
+
+## 关键设计说明
+
+### 两层并发控制
+
+```
+Check 1（节点级）: worker.running >= CONCURRENT_LIMIT * weight
+    → 触发时释放任务，zeroing worker slot，整个 worker 本轮不再接收任务
+
+Check 2（采集源级）: sourceRunning(sid) >= min(source.maxConcurrency, CONCURRENT_LIMIT) * weight
+    sourceRunning(sid) = heartbeat.sourceRunning[sid]   ← 心跳快照（跨 dispatch 周期）
+                       + cycleSourceRunning[sid]        ← 本轮增量（当前 dispatch 周期内）
+    → 触发时释放任务，zeroing worker slot，该 worker 本轮不再接收任务
+```
+
+### 并发公式等价推导
+
+```
+min(source.maxConcurrency, CONCURRENT_LIMIT) * weight
+= min(source.maxConcurrency * weight, CONCURRENT_LIMIT * weight)
+= min(source.maxConcurrency * weight, concurrentLimit)   ← concurrentLimit 已是加权后的值
+```
+
+因此实现中直接使用 `Math.min(floor(source.maxConcurrency * weight), concurrentLimit)`，不需要存储或反推原始 `CONCURRENT_LIMIT`。
+
+## 修改文件
+
+| 文件 | 改动内容 |
+|------|----------|
+| `service/impl/TaskQueueManagerV2Impl.java` | 新增 Check 1 全局限制检查；修正 Check 2 公式；`WorkerSlot` 增加 `cycleSourceRunning` + `sourceRunning()` + `incrementSource()`；限流日志改为 `warn` 级别并携带诊断字段 |
+
+## 验证方式
+
+通过日志过滤验证：
+
+```bash
+# 正常分配（info）：cycleRunning 应逐步递增，不超过 effectiveLimit
+grep "Assigned job" app.log
+
+# 限流触发（warn）：cycleRunning == effectiveLimit 时出现
+grep "Check1\|Check2" app.log
+```
+
+限流日志示例（`warn`）：
+```
+Check2 source limit reached: source=SRC_A sid=7 worker=host-a, job=104 cycleRunning=3 heartbeatRunning=0 effectiveLimit=3
+```

--- a/memory.md
+++ b/memory.md
@@ -208,3 +208,39 @@ grep "Check1\|Check2" app.log
 ```
 Check2 source limit reached: source=SRC_A sid=7 worker=host-a, job=104 cycleRunning=3 heartbeatRunning=0 effectiveLimit=3
 ```
+
+## 未修复项
+
+| # | 问题 | 建议 |
+|---|------|------|
+| 1 | SWRR 在 worker 动态进出时存在轻微 burst/starvation：满载期间 `currentWeight` 无上限累积，恢复后会被连续多选（burst）；若改为只对有 slot 的 worker 累加则反而导致长期不被选中（starvation）。可通过在 Step 1 累加后将 `currentWeight` 钳制在 `totalWeight` 以内修复 | 仅在各节点 `weight` 不同时有影响；默认场景下所有节点 `weight=1.0`，SWRR 退化为 Round-Robin，burst/starvation 不存在，暂不处理 |
+
+---
+
+# 并发控制权威账本修复
+
+> Date: 2026-05-24
+> Branch: `fix/concurrency-control-limit`
+> Build: ✅ `mvn -q -DskipTests -pl backend clean package`
+
+## 背景
+
+master-worker 模式下，`masterDispatch()` 依赖 heartbeat 快照做并发判断，心跳间隔与调度周期不一致，导致跨多个 dispatch 周期累计超发。
+
+## 本次修复
+
+| 文件 | 改动内容 |
+|------|----------|
+| `backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java` | 在 master 侧增加 worker ledger；调度时使用 ledger 作为权威并发账本；分配成功后立即更新本地计数；heartbeat 仅用于对账/纠偏；保留现有 SWRR 选择逻辑 |
+
+## 验证结果
+
+- `effectiveLimit=20` 的 source，`etl01` 触发限流时 `effectiveRunning=20`
+- `effectiveLimit=12` 的 source，`etl02` 触发限流时 `effectiveRunning=12`
+- 未观察到超过源级并发上限的日志
+- `heartbeatRunning` 明显滞后于 `effectiveRunning`，符合“master ledger + heartbeat 对账”的设计
+
+## 当前已知副作用
+
+- 仍存在“先 claim 再 release”的抖动：任务先被 `assignToWorker()` claim，再在 Check1/Check2 里释放回队列
+- 这是下一步要优化的流程问题，不属于本次 bug 修复范围


### PR DESCRIPTION
## Motivation / Background

In the master-worker dispatch flow, the master previously claimed a pending job first and only then checked whether the selected worker still had enough global/source concurrency capacity.

When a job did not fit the current worker ledger, the master would immediately release it back to the queue. This created unnecessary claim/release churn and caused the same jobs to be repeatedly picked and dropped across dispatch cycles.

## What Changed

### `backend/src/main/java/com/wgzhao/addax/admin/service/EtlJobQueueService.java`

Added two new queue operations:

- `peekPendingJobs(int limit)`
  - Read-only view of eligible pending jobs.
  - Does not change queue state.

- `assignSpecificJobToWorker(long jobId, String targetInstanceId, int leaseSeconds)`
  - Atomically claims a specific pending job.
  - Keeps the actual state transition transactional and targeted.

### `backend/src/main/java/com/wgzhao/addax/admin/service/impl/TaskQueueManagerV2Impl.java`

Reworked master dispatch to use a two-step flow:

1. Peek pending jobs without changing queue state.
2. Evaluate whether each job is feasible for the selected worker using the master-side ledger.
3. Only then atomically claim the specific job.

This preserves the existing:

- master-side authoritative concurrency ledger
- SWRR worker selection
- heartbeat reconciliation

while removing the main source of claim/release thrash.

## Design / Implementation Notes

- The master still owns concurrency decisions.
- Heartbeat data remains a reconciliation input, not the sole source of truth.
- The dispatch loop now filters jobs before claiming them.
- If Redis pub/sub delivery fails after claim, the job is still released as a safety fallback.

## Validation

Successfully built the backend with:

```bash
mvn -q -DskipTests -pl backend clean package
```

## Risks / Caveats / Follow-ups

- This change reduces queue thrash, but it does not completely eliminate all release paths:
  - Redis publish failure still falls back to `releaseClaim()`.
- The peek limit is currently bounded by `PENDING_JOB_PEEK_LIMIT` in `TaskQueueManagerV2Impl`.
  - If the queue becomes very large or worker selection patterns change, this limit may need tuning.
- This branch intentionally stays focused on reducing dispatch churn and does not change unrelated scheduling behavior.
