### PR TITLE
feat(api): support multi-status table filtering

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/controller/TableController.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/controller/TableController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 采集表管理接口（RESTful规范），提供采集表的分页查询、详情、统计等功能
@@ -71,7 +72,7 @@ public class TableController
      * @param page 页码（查询参数），默认 0
      * @param pageSize 每页记录数（查询参数），默认 10，-1 表示不分页
      * @param q 查询关键字（查询参数），可选
-     * @param status 状态（查询参数），可选
+    * @param statuses 状态列表（查询参数，逗号分隔），可选
      * @param sortField 排序字段（查询参数），可选
      * @param sortOrder 排序顺序（查询参数），可选
      * @return 采集表分页结果
@@ -81,7 +82,7 @@ public class TableController
         @RequestParam(value = "page", defaultValue = "0") int page,
         @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
         @RequestParam(value = "q", required = false) String q,
-        @RequestParam(value = "status", required = false) String status,
+        @RequestParam(value = "statuses", required = false) String statuses,
         @RequestParam(value = "sourceId", required = false) Integer sourceId,
         @RequestParam(value = "sortField", required = false) String sortField,
         @RequestParam(value = "sortOrder", required = false) String sortOrder)
@@ -92,14 +93,30 @@ public class TableController
         if (pageSize == -1) {
             pageSize = Integer.MAX_VALUE;
         }
+
+        List<String> statusList = parseStatuses(statuses);
         Page<VwEtlTableWithSource> result;
-        if (status != null && !status.isEmpty()) {
-            result = tableService.getVwTablesByStatus(page, pageSize, q, status, sourceId, sortField, sortOrder);
+        if (!statusList.isEmpty()) {
+            result = tableService.getVwTablesByStatuses(page, pageSize, q, statusList, sourceId, sortField, sortOrder);
         }
         else {
             result = tableService.getVwTablesInfo(page, pageSize, q, sourceId, sortField, sortOrder);
         }
         return ResponseEntity.ok(PageResponse.from(result));
+    }
+
+    private List<String> parseStatuses(String statuses)
+    {
+        if (statuses == null || statuses.isBlank()) {
+            return List.of();
+        }
+        return List.of(statuses.split(","))
+            .stream()
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .map(String::toUpperCase)
+            .distinct()
+            .collect(Collectors.toList());
     }
 
     /**

--- a/backend/src/main/java/com/wgzhao/addax/admin/repository/VwEtlTableWithSourceRepo.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/repository/VwEtlTableWithSourceRepo.java
@@ -15,12 +15,21 @@ public interface VwEtlTableWithSourceRepo
 
     Page<VwEtlTableWithSource> findByEnabledIsTrueAndStatusAndFilterColumnContaining(String status, String filterContent, Pageable pageable);
 
+    Page<VwEtlTableWithSource> findByEnabledIsTrueAndStatusInAndFilterColumnContaining(List<String> statuses, String filterContent, Pageable pageable);
+
+    Page<VwEtlTableWithSource> findByEnabledIsTrueAndStatusIn(List<String> statuses, Pageable pageable);
+
     Page<VwEtlTableWithSource> findByEnabledIsTrueAndFilterColumnContaining(String filterContent, Pageable pageable);
 
     Page<VwEtlTableWithSource> findByEnabledIsTrue(Pageable pageable);
 
     // 支持按数据源ID分页查询（sid = source id）
     Page<VwEtlTableWithSource> findBySidAndEnabledIsTrueAndStatusAndFilterColumnContaining(int sid, String status, String filterContent, Pageable pageable);
+
+    Page<VwEtlTableWithSource> findBySidAndEnabledIsTrueAndStatusInAndFilterColumnContaining(int sid, List<String> statuses, String filterContent,
+        Pageable pageable);
+
+    Page<VwEtlTableWithSource> findBySidAndEnabledIsTrueAndStatusIn(int sid, List<String> statuses, Pageable pageable);
 
     Page<VwEtlTableWithSource> findBySidAndEnabledIsTrueAndFilterColumnContaining(int sid, String filterContent, Pageable pageable);
 

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/TableService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/TableService.java
@@ -281,23 +281,37 @@ public class TableService
     }
 
     /**
-     * 根据状态获取视图表信息
+     * 根据状态列表获取视图表信息
      *
      * @param page 页码
      * @param pageSize 每页大小
      * @param q 查询关键字
-     * @param status 表状态
+     * @param statuses 表状态列表
      * @param sortField 排序字段
      * @param sortOrder 排序方式
      * @return 视图表信息分页结果
      */
-    public Page<VwEtlTableWithSource> getVwTablesByStatus(int page, int pageSize, String q, String status, Integer sourceId, String sortField, String sortOrder)
+    public Page<VwEtlTableWithSource> getVwTablesByStatuses(int page, int pageSize, String q, List<String> statuses, Integer sourceId,
+        String sortField, String sortOrder)
     {
         Pageable pageable = PageRequest.of(page, pageSize, QueryUtil.generateSort(sortField, sortOrder));
-        if (sourceId != null) {
-            return vwEtlTableWithSourceRepo.findBySidAndEnabledIsTrueAndStatusAndFilterColumnContaining(sourceId, status, q.toUpperCase(), pageable);
+        boolean hasQuery = q != null && !q.isEmpty();
+        String query = "";
+        if (hasQuery) {
+            query = q.toUpperCase();
         }
-        return vwEtlTableWithSourceRepo.findByEnabledIsTrueAndStatusAndFilterColumnContaining(status, q.toUpperCase(), pageable);
+
+        if (sourceId != null) {
+            if (hasQuery) {
+                return vwEtlTableWithSourceRepo.findBySidAndEnabledIsTrueAndStatusInAndFilterColumnContaining(sourceId, statuses, query, pageable);
+            }
+            return vwEtlTableWithSourceRepo.findBySidAndEnabledIsTrueAndStatusIn(sourceId, statuses, pageable);
+        }
+
+        if (hasQuery) {
+            return vwEtlTableWithSourceRepo.findByEnabledIsTrueAndStatusInAndFilterColumnContaining(statuses, query, pageable);
+        }
+        return vwEtlTableWithSourceRepo.findByEnabledIsTrueAndStatusIn(statuses, pageable);
     }
 
     /**

--- a/frontend/src/service/table-service.ts
+++ b/frontend/src/service/table-service.ts
@@ -16,7 +16,7 @@ class TableService {
     page: number,
     pageSize: number,
     q: string,
-    runStatus?: string,
+    runStatuses?: string[],
     sourceId?: number | null,
     sortBy?: any
   ): Promise<Page<VEtlWithSource>> {
@@ -25,7 +25,7 @@ class TableService {
       page: page,
       pageSize: pageSize,
       q: q,
-      status: runStatus,
+      statuses: runStatuses && runStatuses.length > 0 ? runStatuses.join(',') : undefined,
       sourceId: sourceId,
       sortField: sortBy?.sortField,
       sortOrder: sortBy?.sortOrder,

--- a/frontend/src/views/table/index.vue
+++ b/frontend/src/views/table/index.vue
@@ -27,7 +27,7 @@
     <v-card flat class="ds-card toolbar-card">
       <v-card-text class="ds-card__content">
         <v-row dense align="center">
-          <v-col cols="12" md="2" lg="2">
+          <v-col cols="12" md="2">
             <v-text-field
               v-model="search"
               density="compact"
@@ -40,15 +40,16 @@
               @click:append-inner="searchTable"
             />
           </v-col>
-          <v-col cols="12" md="1" lg="1">
+          <v-col cols="12" md="2">
             <v-select
-              v-model="runStatus"
+              v-model="runStatuses"
               :items="statusOptions"
               item-title="label"
               item-value="value"
               density="compact"
               variant="outlined"
-              single-line
+              multiple
+              clearable
               hide-details
               label="状态"
             />
@@ -335,7 +336,7 @@
   }
 
   const statusOptions = BATCH_UPDATE_STATUS_OPTIONS;
-  const runStatus = ref<string>();
+  const runStatuses = ref<string[]>([]);
   const sourceId = ref<number | null>(null);
   const sourceOptions = ref<any[]>([]);
 
@@ -471,7 +472,7 @@
         page - 1,
         itemsPerPage,
         search.value,
-        runStatus.value,
+        runStatuses.value,
         sourceId.value,
         sortParam
       )


### PR DESCRIPTION
## Motivation / Background
The table management page only supported single-status filtering, which blocked common operations that require viewing multiple statuses together (for example N or Y).

## What Changed
- Frontend table page status filter changed from single-select to multi-select.
- Frontend table service now sends `statuses` (comma-separated) instead of single `status`.
- Backend `/tables` API now accepts `statuses` query parameter and parses it into a distinct uppercase status list.
- Backend table query path now uses IN-based filtering for statuses, with sourceId and keyword combinations preserved.
- Added repository methods for status IN queries (with and without sourceId/keyword).

## Design / Implementation Notes
- This change intentionally does not keep backward compatibility for the old `status` query parameter.
- Empty `statuses` means no status filter is applied.
- Multiple statuses use OR semantics via SQL/JPA IN matching.

## Validation
- bun build:frontend
- bun build:backend

## Risks / Caveats / Follow-ups
- Clients still using `status` must migrate to `statuses`.