### PR TITLE
feat(be): change getMaxValue return type to Object

### DIFF
--- a/backend/src/main/java/com/wgzhao/addax/admin/service/JobContentService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/JobContentService.java
@@ -246,7 +246,7 @@ public class JobContentService
         String partFormat = table.getPartFormat();
         // 转为指定格式
         String partValue = lastEtlDate.format(DateTimeFormatter.ofPattern(partFormat));
-        Long maxValue = targetService.getMaxValue(table, columnName, partValue);
+        Object maxValue = targetService.getMaxValue(table, columnName, partValue);
         if (maxValue == null) {
             // 说明目标表还没有数据或者异常了，那么直接返回 1=1
             // 记录一条风险日志，提醒用户可能存在类型不兼容或查询异常
@@ -258,7 +258,13 @@ public class JobContentService
             }
             return "1=1";
         }
-        return quoteIfNeeded(columnName, getDbType(table.getUrl())) + " > " + maxValue;
+        try {
+            Long.parseLong(maxValue.toString());
+            return quoteIfNeeded(columnName, getDbType(table.getUrl())) + " > " + maxValue;
+        }
+        catch (NumberFormatException e) {
+            return quoteIfNeeded(columnName, getDbType(table.getUrl())) + " > '" + maxValue + "'";
+        }
     }
 
     /**

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/TargetService.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/TargetService.java
@@ -49,7 +49,7 @@ public interface TargetService
     DataSource getHiveDataSourceWithConfig(HiveConnectDto hiveConnectDto)
         throws MalformedURLException;
 
-    Long getMaxValue(VwEtlTableWithSource table, String columnName, String partValue);
+    Object getMaxValue(VwEtlTableWithSource table, String columnName, String partValue);
 
     /**
      * 生成 writer 模板片段。

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TargetServiceImpl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TargetServiceImpl.java
@@ -58,7 +58,7 @@ public class TargetServiceImpl
     }
 
     @Override
-    public Long getMaxValue(VwEtlTableWithSource table, String columnName, String partValue)
+    public Object getMaxValue(VwEtlTableWithSource table, String columnName, String partValue)
     {
         return targetAdapterRegistry.resolve(table).getMaxValue(table, columnName, partValue);
     }

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TargetServiceWithHiveImpl.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/impl/TargetServiceWithHiveImpl.java
@@ -531,7 +531,7 @@ public class TargetServiceWithHiveImpl
         }
     }
 
-    public Long getMaxValue(VwEtlTableWithSource table, String columnName, String partValue)
+    public Object getMaxValue(VwEtlTableWithSource table, String columnName, String partValue)
     {
         if (StringUtils.isEmpty(table.getPartName())) {
             return null;
@@ -544,30 +544,19 @@ public class TargetServiceWithHiveImpl
         try (Connection conn = getHiveConnect();
             Statement stmt = conn.createStatement();
             var rs = stmt.executeQuery(sql)) {
-            Long sqlMax = null;
+            Object sqlMax = null;
             if (rs.next()) {
-                Object maxVal = rs.getObject("max_val");
-                if (maxVal != null) {
-                    try {
-                        sqlMax = Long.parseLong(maxVal.toString());
-                    }
-                    catch (NumberFormatException nfe) {
-                        log.warn("Non-numeric max_val for {}: {}, falling back to redis if available", tableName, maxVal);
-                    }
-                }
+                sqlMax = rs.getObject("max_val");
             }
-
+            if (sqlMax instanceof Number && ((Number) sqlMax).longValue() == 0L) {
+                sqlMax = null;
+            }
             // If sqlMax is null or zero, try to read from redis cache
-            if (sqlMax == null || sqlMax == 0L) {
+            if (sqlMax == null) {
                 try {
-                    String cached = redisTemplate.opsForValue().get(redisKey);
+                    Object cached = redisTemplate.opsForValue().get(redisKey);
                     if (cached != null) {
-                        try {
-                            return Long.parseLong(cached);
-                        }
-                        catch (NumberFormatException nfe) {
-                            log.warn("Cached max value for key {} is not a number: {}", redisKey, cached);
-                        }
+                       return cached;
                     }
                 }
                 catch (Exception e) {
@@ -577,7 +566,7 @@ public class TargetServiceWithHiveImpl
                 return sqlMax;
             }
 
-            // sqlMax is a valid (>0) value: update redis and return
+            // sqlMax is a valid value: update redis and return
             try {
                 redisTemplate.opsForValue().set(redisKey, sqlMax.toString());
             }
@@ -590,9 +579,9 @@ public class TargetServiceWithHiveImpl
             log.error("Failed to get max value for {}.{} ", tableName, columnName, e);
             // on SQL failure, try to read redis as a fallback
             try {
-                String cached = redisTemplate.opsForValue().get(redisKey);
+                Object cached = redisTemplate.opsForValue().get(redisKey);
                 if (cached != null) {
-                    return Long.parseLong(cached);
+                    return cached;
                 }
             }
             catch (Exception ex) {
@@ -672,62 +661,62 @@ public class TargetServiceWithHiveImpl
     }
 
     // Driver shim to wrap a driver loaded from a custom classloader so DriverManager can use it
-        private record DriverShim(Driver driver)
-            implements Driver
+    private record DriverShim(Driver driver)
+        implements Driver
+    {
+
+        @Override
+        public boolean acceptsURL(String u)
+            throws SQLException
         {
+            return driver.acceptsURL(u);
+        }
 
-            @Override
-            public boolean acceptsURL(String u)
-                throws SQLException
-            {
-                return driver.acceptsURL(u);
+        @Override
+        public Connection connect(String u, Properties p)
+            throws SQLException
+        {
+            return driver.connect(u, p);
+        }
+
+        @Override
+        public int getMajorVersion()
+        {
+            return driver.getMajorVersion();
+        }
+
+        @Override
+        public int getMinorVersion()
+        {
+            return driver.getMinorVersion();
+        }
+
+        @Override
+        public DriverPropertyInfo[] getPropertyInfo(String u, Properties p)
+            throws SQLException
+        {
+            return driver.getPropertyInfo(u, p);
+        }
+
+        @Override
+        public boolean jdbcCompliant()
+        {
+            return driver.jdbcCompliant();
+        }
+
+        @Override
+        public Logger getParentLogger()
+            throws SQLFeatureNotSupportedException
+        {
+            try {
+                return driver.getParentLogger();
             }
-
-            @Override
-            public Connection connect(String u, Properties p)
-                throws SQLException
-            {
-                return driver.connect(u, p);
-            }
-
-            @Override
-            public int getMajorVersion()
-            {
-                return driver.getMajorVersion();
-            }
-
-            @Override
-            public int getMinorVersion()
-            {
-                return driver.getMinorVersion();
-            }
-
-            @Override
-            public DriverPropertyInfo[] getPropertyInfo(String u, Properties p)
-                throws SQLException
-            {
-                return driver.getPropertyInfo(u, p);
-            }
-
-            @Override
-            public boolean jdbcCompliant()
-            {
-                return driver.jdbcCompliant();
-            }
-
-            @Override
-            public Logger getParentLogger()
-                throws SQLFeatureNotSupportedException
-            {
-                try {
-                    return driver.getParentLogger();
-                }
-                catch (AbstractMethodError ame) {
-                    // some older drivers don't implement this
-                    throw new SQLFeatureNotSupportedException(ame);
-                }
+            catch (AbstractMethodError ame) {
+                // some older drivers don't implement this
+                throw new SQLFeatureNotSupportedException(ame);
             }
         }
+    }
 
     @PreDestroy
     public void destroy()

--- a/backend/src/main/java/com/wgzhao/addax/admin/service/target/TargetAdapter.java
+++ b/backend/src/main/java/com/wgzhao/addax/admin/service/target/TargetAdapter.java
@@ -17,7 +17,7 @@ public interface TargetAdapter
 
     boolean createOrUpdateTable(VwEtlTableWithSource etlTable);
 
-    Long getMaxValue(VwEtlTableWithSource table, String columnName, String partValue);
+    Object getMaxValue(VwEtlTableWithSource table, String columnName, String partValue);
 
     /**
      * 执行任务前的目标端准备动作（如分区创建）。


### PR DESCRIPTION
feat(be): change getMaxValue return type to Object

Why: support non-numeric max values (e.g. string partitions) and avoid
parsing errors when composing predicates or reading cached values.

What: change getMaxValue signature from Long to Object in
TargetService/TargetAdapter and implementations; return raw objects from
Hive impl and Redis cache; update JobContentService to quote non-numeric
values when building WHERE clauses; small DriverShim formatting fixes.

Impact: backend API method signature changed; requires recompilation of
callers/adapters and may break code that assumes a Long return.

Test: built backend and exercised Hive max retrieval and job predicate
generation paths manually; adjusted code paths handle numeric and string
max values.

